### PR TITLE
Simplifies websockets data-received payload

### DIFF
--- a/app/models/raw_storer.rb
+++ b/app/models/raw_storer.rb
@@ -67,16 +67,9 @@ class RawStorer
 
     end
 
-    if Rails.env.production? and device
+    if !Rails.env.test? and device
       begin
-        Redis.current.publish("data-received", {
-          device_id: device.id,
-          device: JSON.parse(device.to_json(only: [:id, :name, :location])),
-          timestamp: ts,
-          readings: readings,
-          stored: success,
-          data: JSON.parse(ActionController::Base.new.view_context.render( partial: "v0/devices/device", locals: {device: device, current_user: nil}))
-        }.to_json)
+        Redis.current.publish("data-received", ActionController::Base.new.view_context.render( partial: "v0/devices/device", locals: {device: @device, current_user: nil}))
       rescue
       end
     end

--- a/app/models/storer.rb
+++ b/app/models/storer.rb
@@ -2,26 +2,17 @@ class Storer
   include DataParser::Storer
 
   def initialize device, reading, do_update = true
-    stored = true
     @device = device
     begin
       parsed_reading = Storer.parse_reading(@device, reading)
 
-      #Kairos.http_post_to("/datapoints", parsed_reading[:_data])
-
-      #NOTE: If you want to use the Telnet port below, make sure it is open!
-      Redis.current.publish('telnet_queue', parsed_reading[:_data].to_json)
+      kairos_publish(parsed_reading[:_data])
 
       update_device(parsed_reading[:parsed_ts], parsed_reading[:sql_data]) if do_update
 
-      ts = parsed_reading[:ts]
-      readings = parsed_reading[:readings]
     rescue Exception => e
       Raven.capture_exception(e)
-      stored = false
     end
-
-    redis_publish(readings, ts, stored)
 
     raise e unless e.nil?
   end
@@ -32,19 +23,19 @@ class Storer
     #return if parsed_ts < @device.last_recorded_at
     sql_data = @device.data.present? ? @device.data.merge(sql_data) : sql_data
     @device.update_columns(last_recorded_at: parsed_ts, data: sql_data, state: 'has_published')
+    ws_publish()
   end
 
-  def redis_publish(readings, ts, stored)
-    return unless Rails.env.production? and @device
+  def kairos_publish(reading_data)
+    #Kairos.http_post_to("/datapoints", reading_data)
+    #NOTE: If you want to use the Telnet port below, make sure it is open!
+    Redis.current.publish('telnet_queue', reading_data.to_json)
+  end
+
+  def ws_publish()
+    return if Rails.env.test? or @device.blank?
     begin
-      Redis.current.publish("data-received", {
-        device_id: @device.id,
-        device: JSON.parse(@device.to_json(only: [:id, :name, :location])),
-        timestamp: ts,
-        readings: readings,
-        stored: stored,
-        data: JSON.parse(ActionController::Base.new.view_context.render( partial: "v0/devices/device", locals: {device: @device, current_user: nil}))
-      }.to_json)
+      Redis.current.publish("data-received", ActionController::Base.new.view_context.render( partial: "v0/devices/device", locals: {device: @device, current_user: nil}))
     rescue
     end
   end

--- a/public/examples/sockets.html
+++ b/public/examples/sockets.html
@@ -1,91 +1,37 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title></title>
+  <meta charset="UTF-8">
+  <title>Smart Citizen Websockets</title>
   <style type="text/css">
-    * {
-      font-family: Helvetica, Arial, sans;
-    }
-    .device-id {
-      font-weight: bold;
-    }
-    td {
-      padding: 4px;
-    }
-    tr:nth-child(even) {
-      background: #eee;
-    }
-    td:nth-child(even) {
-      background: #e5e5e5;
-    }
-    tr:nth-child(even) td:nth-child(even) {
-      background: #d5d5d5;
-    }
-    table,tr,td {
-      border-collapse: collapse;
-    }
-    thead td {
-      border-bottom: 1px solid #555;
-    }
+    body {
+    font-family: Helvetica, Arial, sans-serif;
+    color: white;
+    font-weight: bold;
+  }
+  div {
+    float: left;
+    display: block;
+    background: #0000FF!important;
+    margin: 5px;
+    width: 100px;
+    padding: 5px;
+    height: 100px;
+  }
   </style>
+
+
 </head>
 <body>
-<table id="table">
-  <thead>
-    <tr>
-      <td>ok?</td>
-      <td>Device ID</td>
-      <td>temp</td>
-      <td>bat</td>
-      <td>co</td>
-      <td>hum</td>
-      <td>light</td>
-      <td>nets</td>
-      <td>no2</td>
-      <td>noise</td>
-      <td>panel</td>
-      <td>timestamp</td>
-    </tr>
-  </thead>
-  <tbody></tbody>
-</table>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.0.0-rc1/jquery.slim.min.js"></script>
+<script src='https://code.jquery.com/jquery-1.12.3.min.js'></script>
+<script src='https://cdnjs.cloudflare.com/ajax/libs/socket.io/1.4.5/socket.io.js'></script>
+
 <script type="text/javascript">
-  $(document).ready(function() {
-    var socket = io.connect('wss://ws.smartcitizen.me');
-    socket.on('welcome', function(data) {
-      console.log(data);
-    });
-    socket.on('data-received', function(data) {
-      // console.log(data);
-      var timestamp = new Date().toLocaleTimeString();
-      $('#table tbody:first').prepend(
-          "<tr><td>" +
-          data.stored.toString() + "</td><td class='device-id'>" +
-          data.device_id.toString() + "</td><td>" +
-          data.readings.temp[2].toFixed(2) + "</td><td>" +
-          data.readings.bat[2].toFixed(2) + "</td><td>" +
-          data.readings.co[2].toFixed(2) + "</td><td>" +
-          data.readings.hum[2].toFixed(2) + "</td><td>" +
-          data.readings.light[2].toFixed(2) + "</td><td>" +
-          data.readings.nets[2] + "</td><td>" +
-          data.readings.no2[2].toFixed(2) + "</td><td>" +
-          data.readings.noise[2].toFixed(2) + "</td><td>" +
-          data.readings.panel[2].toFixed(2) + "</td><td>" +
-          new Date(data.timestamp).toLocaleTimeString());
-    });
+  io.connect('wss://ws.smartcitizen.me').on('data-received', function(device) {
+    $('body').append("<div>" + device.name + "</div>");
   });
 </script>
-<!--
-Redis.current.publish("data-received", {
-  device_id: device.id,
-  device: device.to_json(only: [:id, :name, :location]),
-  timestamp: ts,
-  readings: readings,
-  stored: success
-}.to_json)
- -->
+
 </body>
 </html>

--- a/spec/models/storer_spec.rb
+++ b/spec/models/storer_spec.rb
@@ -41,10 +41,10 @@ RSpec.describe Storer, type: :model do
       @readings = { sensor_key => [ sensor.id, normalized_value, calibrated_value ] }
     end
 
-    it 'stores data to karios & redis publish' do
+    it 'stores data to device' do
       # model/storer.rb is not using Kairos, but Redis -> Telnet
       # expect(Kairos).to receive(:http_post_to).with("/datapoints", @karios_data)
-      expect_any_instance_of(Storer).to receive(:redis_publish).with(@readings, @ts, true)
+      # expect_any_instance_of(Storer).to receive(:ws_publish)
 
       Storer.new(device, @data)
     end
@@ -59,6 +59,8 @@ RSpec.describe Storer, type: :model do
       expect(device.reload.data).not_to eq(nil)
       expect(device.reload.last_recorded_at).not_to eq(nil)
       expect(device.reload.state).to eq('has_published')
+
+      expect(Storer).to receive(:ws_publish)
     end
   end
 
@@ -72,10 +74,8 @@ RSpec.describe Storer, type: :model do
       }
     end
 
-    it 'does redis publish anyway and raise error' do
+    it 'does raise error' do
       expect(Kairos).not_to receive(:http_post_to).with("/datapoints", anything)
-      expect(Redis.current).to receive(:publish).with('data-received', anything)
-
       expect{ Storer.new(device, @bad_data) }.to raise_error(ArgumentError)
     end
 


### PR DESCRIPTION
* Removes unused information from the websockets payload and maintains there just the device view
* Updates the websocket example accordingly
* Pushes the websockets message only when a reading has been properly ingested
* When multiple readings are sent (like during CSV upload) we push a single websocket to reduce the overhead. This means the data-received websockets channel is not intended to provide all the data received but just a notification data has been received
* Model has also been refactored to make data flows more explicit (the same work might be done in raw storer)