### PR TITLE
Don't update last_reading if not the latest

### DIFF
--- a/app/models/storer.rb
+++ b/app/models/storer.rb
@@ -20,7 +20,7 @@ class Storer
   def update_device(parsed_ts, sql_data)
     return unless parsed_ts > Time.at(0)
     # Next line fails if @device.last_recorded_at is nil
-    #return if parsed_ts < @device.last_recorded_at
+    return if parsed_ts < @device.last_recorded_at
     sql_data = @device.data.present? ? @device.data.merge(sql_data) : sql_data
     @device.update_columns(last_recorded_at: parsed_ts, data: sql_data, state: 'has_published')
     ws_publish()


### PR DESCRIPTION
This prevents showing a wrong last_reading when a device publishes multiple readings not sorted from oldest to newest