### PR TITLE
Handle device not found

### DIFF
--- a/app/lib/mqtt_messages_handler.rb
+++ b/app/lib/mqtt_messages_handler.rb
@@ -55,8 +55,12 @@ class MqttMessagesHandler
 
   def self.handle_hardware_info(topic, message)
     device_token = self.device_token(topic)
-    dev = Device.where(device_token: device_token).first
-    dev.update_attributes hardware_info: JSON.parse(message)
+    device = Device.where(device_token: device_token).first
+    if device.present?
+      device.update_attributes hardware_info: JSON.parse(message)
+    else
+      # Device with this device_token likely not found
+    end
   end
 
   def self.handle_inventory(topic, message)

--- a/app/lib/mqtt_messages_handler.rb
+++ b/app/lib/mqtt_messages_handler.rb
@@ -26,9 +26,8 @@ class MqttMessagesHandler
     end
   rescue Exception => e
     Raven.capture_exception(e)
-    puts e.message
-    puts message
-    #Airbrake.notify(e, {payload: e.message + " - payload: " + message})
+    #puts e.inspect
+    #puts message
   end
 
   def self.handle_hello(topic, message)
@@ -55,12 +54,9 @@ class MqttMessagesHandler
 
   def self.handle_hardware_info(topic, message)
     device_token = self.device_token(topic)
-    device = Device.where(device_token: device_token).first
-    if device.present?
-      device.update_attributes hardware_info: JSON.parse(message)
-    else
-      # Device with this device_token likely not found
-    end
+    device = Device.find_by(device_token: device_token)
+    return if device.blank?
+    device.update_attributes hardware_info: JSON.parse(message)
   end
 
   def self.handle_inventory(topic, message)


### PR DESCRIPTION
TODO:
- [ ] Add `test` for when a device is not found
- [ ] What to do if it is not found? Simply do nothing?
- [ ] Refactor: create a method to reuse the `device = Device.find_by(device_token: self.device_token(topic))` in more places?

Sentry error screenshot:
![2019-10-23_15-17-14](https://user-images.githubusercontent.com/1689020/67396686-4f953480-f5a8-11e9-8a9d-9b677ce6ec91.png)
