### PR TITLE
Force SSL + Forward SSL from Nginx to the container

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
   config.active_storage.service = :amazon
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/scripts/nginx-conf/api.smartcitizen.me.conf
+++ b/scripts/nginx-conf/api.smartcitizen.me.conf
@@ -25,6 +25,7 @@ server {
 
   location @app {
     proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Ssl on; # Optional
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;
     proxy_redirect off;
@@ -69,6 +70,7 @@ server {
   location @app {
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Ssl on; # Optional
     proxy_set_header Host $http_host;
     proxy_redirect off;
     proxy_pass http://app:3000;


### PR DESCRIPTION
Was causing http urls instead of https. see:
https://github.com/fablabbcn/smartcitizen-api/issues/166

Solution is to force use SSL, and forward it from Nginx to the container
See more: https://github.com/rails/rails/issues/22965

If this works without problems, we can also update the **auth** container to use `force_ssl = true`

- [ ] Remember to check the AUTH container after deployment