### PR TITLE
Feat mqtt persistance

### DIFF
--- a/env.example
+++ b/env.example
@@ -17,6 +17,7 @@ REDIS_URL=redis://redis:6379/0
 REDIS_STORE=redis://redis:6379/3
 
 mqtt_host=mqtt
+mqtt_client=smartcitizen-api
 
 # Cassandra IP - this is not used?
 #cassandra_host_ip=localhost

--- a/lib/tasks/mqtt_subscriber.rake
+++ b/lib/tasks/mqtt_subscriber.rake
@@ -10,7 +10,7 @@ namespace :mqtt do
 
     begin
       mqtt_log.info "Connecting to #{host} ..."
-      MQTT::Client.connect(host: host, clean_session: true) do |client|
+      MQTT::Client.connect(host: host, clean_session: false) do |client|
         mqtt_log.info "Connected to #{client.host}"
 
         client.subscribe(

--- a/lib/tasks/mqtt_subscriber.rake
+++ b/lib/tasks/mqtt_subscriber.rake
@@ -7,10 +7,11 @@ namespace :mqtt do
 
     # Use docker container 'mqtt' if not defined
     host = ENV['mqtt_host'] || 'mqtt'
+    client_id = ENV['mqtt_client'] || 'demo'
 
     begin
       mqtt_log.info "Connecting to #{host} ..."
-      MQTT::Client.connect(host: host, clean_session: false, client_id: 'test') do |client|
+      MQTT::Client.connect(host: host, clean_session: false, client_id: client_id) do |client|
         mqtt_log.info "Connected to #{client.host}"
 
         client.subscribe(

--- a/lib/tasks/mqtt_subscriber.rake
+++ b/lib/tasks/mqtt_subscriber.rake
@@ -10,7 +10,7 @@ namespace :mqtt do
 
     begin
       mqtt_log.info "Connecting to #{host} ..."
-      MQTT::Client.connect(host: host, clean_session: false) do |client|
+      MQTT::Client.connect(host: host, clean_session: false, client_id: 'test') do |client|
         mqtt_log.info "Connected to #{client.host}"
 
         client.subscribe(


### PR DESCRIPTION
Sets the platform MQTT subscriber on persistent connection mode, enabling the app to recover all the non ingested messages from the broker if it accidentally disconnects