### PR TITLE
Fix PG foreign key error on deleting devices

### DIFF
--- a/app/jobs/delete_archived_devices_job.rb
+++ b/app/jobs/delete_archived_devices_job.rb
@@ -6,7 +6,7 @@ class DeleteArchivedDevicesJob < ApplicationJob
     CheckupNotifyJob.perform_now("Delete archived devices")
 
     Device.unscoped.where(workflow_state: "archived").each do |device|
-      if device.created_at < 24.hours.ago
+      if device.archived_at < 24.hours.ago
         CheckupNotifyJob.perform_now("deleting archived device #{device.id}")
         device.destroy!
       end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -23,7 +23,7 @@ class Device < ActiveRecord::Base
   has_many :tags, through: :devices_tags
   has_many :components, as: :board
   has_many :sensors, through: :components
-  has_one :postprocessing
+  has_one :postprocessing, dependent: :destroy
 
   accepts_nested_attributes_for :postprocessing, update_only: true
 

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -136,13 +136,15 @@ class Device < ActiveRecord::Base
   end
 
   def archive
-    update({mac_address: nil, old_mac_address: mac_address})
+    update({mac_address: nil, old_mac_address: mac_address, archived_at: Time.now})
   end
 
   def unarchive
+    updates = { archived_at: nil }
     unless Device.unscoped.where(mac_address: old_mac_address).exists?
-      update({mac_address: old_mac_address, old_mac_address: nil})
+      updates.merge!({mac_address: old_mac_address, old_mac_address: nil})
     end
+    update(updates)
   end
 
   def firmware

--- a/db/migrate/20230512075843_add_archived_at_to_devices.rb
+++ b/db/migrate/20230512075843_add_archived_at_to_devices.rb
@@ -1,0 +1,14 @@
+class AddArchivedAtToDevices < ActiveRecord::Migration[6.0]
+  def up
+    add_column :devices, :archived_at, :datetime, null: true
+    execute %{
+      UPDATE devices
+      SET archived_at = NOW()
+      WHERE state = 'archived'
+    }
+  end
+
+  def down
+    remove_column :devices, :archived_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_04_124227) do
+ActiveRecord::Schema.define(version: 2023_05_12_075843) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "adminpack"
@@ -95,6 +95,7 @@ ActiveRecord::Schema.define(version: 2021_02_04_124227) do
     t.boolean "notify_stopped_publishing", default: false
     t.boolean "is_private", default: false
     t.boolean "is_test", default: false, null: false
+    t.datetime "archived_at"
     t.index ["device_token"], name: "index_devices_on_device_token", unique: true
     t.index ["geohash"], name: "index_devices_on_geohash"
     t.index ["kit_id"], name: "index_devices_on_kit_id"

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -417,4 +417,16 @@ RSpec.describe Device, :type => :model do
     end
   end
 
+  context "deletion" do
+    it "deletes the associated postprocessing info" do
+      device = create(:device)
+      device.create_postprocessing!
+      expect {
+        device.destroy!
+      }.not_to raise_error
+      expect(Postprocessing.count).to eq(0)
+      expect(Device.count).to eq(0)
+    end
+  end
+
 end


### PR DESCRIPTION
This fixes #214 - deleting devices failed since we moved the postprocessing data to a seperate table, as the foreign key constraint prevented the postprocessing table entry being orphaned.

The solution is to make this relationship `depenedent: destroy` - when a device is removed, we remove its postprocessing info too.

I've also added a test to guard against regressions here and make the behaviour we expect explicit.