### PR TITLE
Bugfix: CSV download sort order (#215)

### DIFF
--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -23,7 +23,7 @@ class Device < ActiveRecord::Base
   has_many :tags, through: :devices_tags
   has_many :components, as: :board
   has_many :sensors, through: :components
-  has_one :postprocessing
+  has_one :postprocessing, dependent: :destroy
 
   accepts_nested_attributes_for :postprocessing, update_only: true
 

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -417,4 +417,16 @@ RSpec.describe Device, :type => :model do
     end
   end
 
+  context "deletion" do
+    it "deletes the associated postprocessing info" do
+      device = create(:device)
+      device.create_postprocessing!
+      expect {
+        device.destroy!
+      }.not_to raise_error
+      expect(Postprocessing.count).to eq(0)
+      expect(Device.count).to eq(0)
+    end
+  end
+
 end


### PR DESCRIPTION
Metrics provided by an HTTP post after postprocessing were showing up out-of-order
in the CSV, apended after the sensor data received directly. This was due to the fact that
the CSV table is built column-wise rather than row-wise, and ruby hashes preserve the order of
insertion, not of their keys, as detailed in #215 .

To fix this, we've added an explicit sort by timestamp at the end, this returns an array rather
than a hash, so have renamed the method and refactored to suit.

Still TODO: better test coverage and some refactoring of this class, as this logic could be made
much clearer.