### PR TITLE
WIP - use https for user profile urls

### DIFF
--- a/app/views/v0/users/_user.jbuilder
+++ b/app/views/v0/users/_user.jbuilder
@@ -12,15 +12,9 @@ json.(user,
 )
 
 if user.profile_picture.attached?
-  # TODO: Active Storage: dont manually splice the URLs together. Use Active Storage standard way for getting full URL
-  json.profile_picture request.base_url + url_for(user.profile_picture)
-  #json.profile_picture2 request.base_url + url_for(user.profile_picture.variant(resize:"100x100"))
+  json.profile_picture polymorphic_url(user.profile_picture, only_path: false)
+
 else
-  # The angular frontend checks if this is empty.
-  # If profile_picture is empty, it will use the avatar url
-  # If the avatar is also empty, it will use default.svg
-  # So it is better to leave this empty, for now, until stop the avatar property
-  #json.profile_picture 'https://smartcitizen.s3.amazonaws.com/avatars/default.svg'
   json.profile_picture ''
 end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,8 +28,8 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :amazon
-  #config.active_storage.service = :local
+  #config.active_storage.service = :amazon
+  config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/initializers/force_ssl.rb
+++ b/config/initializers/force_ssl.rb
@@ -1,0 +1,3 @@
+if Rails.application.config.force_ssl
+  Rails.application.routes.default_url_options[:protocol] = "https"
+end


### PR DESCRIPTION
This i've tested succesfully in staging - the fact that it relies on SSL makes it difficult to write specs for

```json
{
    "id": 3,
    "uuid": "6c9a7299-e315-4a32-a36c-b6df730dafa5",
    "role": "admin",
    "username": "tim",
    "avatar": "https://smartcitizen.s3.amazonaws.com/avatars/default.svg",
    "profile_picture": "https://staging-api.smartcitizen.me/rails/active_storage/blobs/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBCZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--ae4708c28450a738096a6dfeeaa9e7aab12086ac/tim.jpg",
    "url": null,
    "location": {
      "city": null,
      "country": null,
      "country_code": null
    },
    "joined_at": "2023-05-25T06:54:00Z",
    "updated_at": "2023-05-25T06:55:51Z",
    "email": "[FILTERED]",
    "legacy_api_key": "[FILTERED]",
    "devices": []
  }
```

In case of any issues, it might be worth  running `rails tmp:clear` after deploying, as [mentioned here](https://github.com/rails/rails/issues/33160).