### PR TITLE
Populate archived_at field on devices for archived devices

### DIFF
--- a/db/migrate/20230705095430_populate_device_archived_at_column.rb
+++ b/db/migrate/20230705095430_populate_device_archived_at_column.rb
@@ -1,0 +1,9 @@
+class PopulateDeviceArchivedAtColumn < ActiveRecord::Migration[6.0]
+  def change
+    execute %{
+      UPDATE devices
+      SET archived_at = NOW()
+      WHERE workflow_state = 'archived'
+    }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_12_075843) do
+ActiveRecord::Schema.define(version: 2023_07_05_095430) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "adminpack"
@@ -89,8 +89,8 @@ ActiveRecord::Schema.define(version: 2023_05_12_075843) do
     t.string "state"
     t.string "device_token"
     t.jsonb "hardware_info"
-    t.datetime "notify_stopped_publishing_timestamp", default: "2019-01-16 16:19:35"
-    t.datetime "notify_low_battery_timestamp", default: "2019-01-16 16:19:35"
+    t.datetime "notify_stopped_publishing_timestamp", default: "2019-01-21 16:07:41"
+    t.datetime "notify_low_battery_timestamp", default: "2019-01-21 16:07:41"
     t.boolean "notify_low_battery", default: false
     t.boolean "notify_stopped_publishing", default: false
     t.boolean "is_private", default: false


### PR DESCRIPTION
This corrects an oversight in my previous PR which created the field but didn't set it for previously-archived devices.