### PR TITLE
Add possibility to connect via ssl to broker

### DIFF
--- a/env.example
+++ b/env.example
@@ -20,7 +20,8 @@ REDIS_STORE=redis://redis:6379/3
 MQTT_HOST=mqtt
 #MQTT_CLEAN_SESSION=true
 #MQTT_CLIENT_ID=some_id
-
+#MQTT_PORT=port
+#MQTT_SSL=false
 aws_secret_key=123
 
 # kairos Dockerized

--- a/lib/tasks/mqtt_subscriber.rake
+++ b/lib/tasks/mqtt_subscriber.rake
@@ -7,17 +7,23 @@ namespace :mqtt do
     mqtt_clean_session = ENV.has_key?('MQTT_CLEAN_SESSION') ? ENV['MQTT_CLEAN_SESSION'] == "true" : true
     mqtt_client_id = ENV.has_key?('MQTT_CLIENT_ID') ? ENV['MQTT_CLIENT_ID'] : nil
     mqtt_host = ENV.has_key?('MQTT_HOST') ? ENV['MQTT_HOST'] : 'mqtt'
+    mqtt_port = ENV.has_key?('MQTT_PORT') ? ENV['MQTT_PORT'] : 1883
+    mqtt_ssl = ENV.has_key?('MQTT_SSL') ? ENV['MQTT_SSL'] : false
 
     mqtt_log.info('MQTT TASK STARTING')
     mqtt_log.info("clean_session: #{mqtt_clean_session}")
     mqtt_log.info("client_id: #{mqtt_client_id}")
     mqtt_log.info("host: #{mqtt_host}")
+    mqtt_log.info("port: #{mqtt_port}")
+    mqtt_log.info("ssl: #{mqtt_ssl}")
 
     begin
       MQTT::Client.connect(
         :host => mqtt_host,
+        :port => mqtt_port,
         :clean_session => mqtt_clean_session,
-        :client_id => mqtt_client_id
+        :client_id => mqtt_client_id,
+        :ssl => mqtt_ssl
       ) do |client|
 
         mqtt_log.info "Connected to #{client.host}"


### PR DESCRIPTION
This PR adds the possibility to connect via `1883` default port to mqtt broker in `lib/task/mqtt-subscriber.rake`, or to add an extra env variable in `.env` that would allow for a `ssl` connection through another port.