### PR TITLE
Update base image for Kairos docker container.

### DIFF
--- a/scripts/Dockerfile-kairos
+++ b/scripts/Dockerfile-kairos
@@ -1,4 +1,4 @@
-FROM java:8-alpine
+FROM openjdk:8-jdk-alpine
 
 RUN apk upgrade libssl1.0 --update-cache && \
     apk add wget \


### PR DESCRIPTION
The previous java8 / alpine linux container was removed, so instead we're using the openjdk 8 alpine image. This builds and runs locally, but will need some thorough testing in staging.