### PR TITLE
update latest migration version in schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_16_151555) do
+ActiveRecord::Schema.define(version: 2023_07_05_095430) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "adminpack"


### PR DESCRIPTION
Today I learned that writing migrations which don't affect the db schema put the db version in schema.rb out of sync with the migration versions, and cause all sorts of problems.