### PR TITLE
Ensure that devices are searchable by the presence of a postprocessing

### DIFF
--- a/app/models/postprocessing.rb
+++ b/app/models/postprocessing.rb
@@ -1,3 +1,7 @@
 class Postprocessing < ApplicationRecord
   belongs_to :device
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["blueprint_url", "created_at", "device_id", "forwarding_params", "hardware_url", "id", "latest_postprocessing", "meta", "updated_at"]
+  end
 end

--- a/spec/requests/v0/devices_spec.rb
+++ b/spec/requests/v0/devices_spec.rb
@@ -114,6 +114,11 @@ describe V0::DevicesController do
         expect(response.status).to eq(400)
       end
 
+      it "allows searching by presence of postprocessing" do
+        json = api_get "devices?q[postprocessing_id_not_null]=1"
+        expect(response.status).to eq(200)
+      end
+
     end
   end
 


### PR DESCRIPTION
Fixes #254 - this is an API change in the new version of Ransack - searchable parameters have to be explicitly whitelisted. We probably need to investigate to see if there are any others that are used habitually, in the meantime this will fix the immediate issue with postprocessings.