### PR TITLE
Delete archived devices which have a null archived_at date.

### DIFF
--- a/app/jobs/delete_archived_devices_job.rb
+++ b/app/jobs/delete_archived_devices_job.rb
@@ -6,7 +6,7 @@ class DeleteArchivedDevicesJob < ApplicationJob
     CheckupNotifyJob.perform_now("Delete archived devices")
 
     Device.unscoped.where(workflow_state: "archived").each do |device|
-      if device.archived_at < 24.hours.ago
+      if !device.archived_at || device.archived_at < 24.hours.ago
         CheckupNotifyJob.perform_now("deleting archived device #{device.id}")
         device.destroy!
       end

--- a/spec/jobs/delete_archived_devices_job_spec.rb
+++ b/spec/jobs/delete_archived_devices_job_spec.rb
@@ -10,19 +10,23 @@ RSpec.describe DeleteArchivedDevicesJob, type: :job do
       }.to have_enqueued_job
     end
 
-    it "should delete all archived devices, archived_at at least 24 hours ago" do
-      deviceNormal = create(:device, name: "dontDeleteMe", created_at: 6.weeks.ago)
-      deviceArchived = create(:device, name: "deleteMe", created_at: 1.month.ago)
-      deviceArchivedToday = create(:device, name: "dontDeleteMe", created_at: 2.months.ago)
+    it "should delete all archived devices, archived_at at least 24 hours ago, or without an archived_at date" do
+      deviceNormal = create(:device, name: "dontDeleteMe - not archived")
+      deviceArchived = create(:device, name: "deleteMe")
+      deviceArchivedToday = create(:device, name: "dontDeleteMe - archived today")
+      deviceArchivedWithNullTime = create(:device, name: "deleteMe - null")
       deviceArchived.archive!
       deviceArchivedToday.archive!
+      deviceArchivedWithNullTime.archive!
       deviceArchived.update!({archived_at: 2.days.ago})
+      deviceArchivedWithNullTime.update!({archived_at: nil})
       expect {
         DeleteArchivedDevicesJob.perform_now
-      }.to change(Device.unscoped, :count).by(-1)
+      }.to change(Device.unscoped, :count).by(-2)
       expect(Device.unscoped).to include(deviceNormal)
       expect(Device.unscoped).not_to include(deviceArchived)
       expect(Device.unscoped).to include(deviceArchivedToday)
+      expect(Device.unscoped).not_to include(deviceArchivedWithNullTime)
     end
   end
 end


### PR DESCRIPTION
Fixes #252. 
For some reason, we've got some legacy devices which never had their archived_at date set, which are causing the deletion job to crash, meaning that neither they (nor archived devices with subsequent IDs) are deleted. This adds a test for the failure, and fixes so that all archived devices with a null archived_at are deleted. This shouldn't cause a problem in future as only old devices have the null archived_at date.