### PR TITLE
Enable sentry breadcrumbs

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,3 +1,4 @@
 Sentry.init do |config|
   config.dsn = ENV['RAVEN_DSN_URL']
+  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
 end


### PR DESCRIPTION
Sentry has a [feature called breadcrumbs](https://docs.sentry.io/platforms/ruby/configuration/options/) which might help us track down some of those weirder bugs (the Puma one, and the JSON one)? This enables it in the api.