### PR TITLE
Better sentry logging in MQTT message handler

### DIFF
--- a/app/lib/mqtt_messages_handler.rb
+++ b/app/lib/mqtt_messages_handler.rb
@@ -20,13 +20,7 @@ class MqttMessagesHandler
     elsif topic.to_s.include?('readings')
       handle_readings(device, message)
     elsif topic.to_s.include?('info')
-      begin
-        json_info = JSON.parse(message)
-      rescue Exception => e
-        e.message << "\nmessage: #{message}"
-        raise e
-      end
-      device.update hardware_info: json_info
+      device.update hardware_info: JSON.parse(message)
     end
   end
 
@@ -57,12 +51,7 @@ class MqttMessagesHandler
       reading['data'].first['sensors'] << { 'id' => raw_id, 'value' => raw_value }
     end
 
-    begin
-      JSON[reading]
-    rescue Exception => e
-      e.message << "\nreading: #{reading}"
-      raise e
-    end
+    JSON[reading]
   end
 
   def self.handle_hello(orphan_device)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,4 +1,4 @@
 Sentry.init do |config|
   config.dsn = ENV['RAVEN_DSN_URL']
-  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+  config.breadcrumbs_logger = [:sentry_logger, :active_support_logger, :http_logger]
 end


### PR DESCRIPTION
Enabled Sentry's [Sidekiq integration](https://docs.sentry.io/platforms/ruby/guides/sidekiq/) properly, and added some manual [Breadcrumbs](https://docs.sentry.io/platforms/ruby/guides/rails/enriching-events/breadcrumbs/) to better track what's going on in the MQTT message handler.

If we could get this to production when we meet next week so i can better understand those last few remaining errors from the upgrade, that'd be ace!