### PR TITLE
set sentry scopes properly in rake tasks

### DIFF
--- a/lib/tasks/mqtt_subscriber.rake
+++ b/lib/tasks/mqtt_subscriber.rake
@@ -38,10 +38,14 @@ namespace :mqtt do
         )
 
         client.get do |topic, message|
-          MqttMessagesHandler.handle_topic(topic, message)
-        rescue Exception => e
-          mqtt_log.info e
-          Sentry.capture_exception(e)
+          Sentry.with_scope do
+            begin
+              MqttMessagesHandler.handle_topic(topic, message)
+            rescue Exception => e
+              mqtt_log.info e
+              Sentry.capture_exception(e)
+            end
+          end
         end
       end
     rescue SystemExit, Interrupt, SignalException

--- a/lib/tasks/telnet.rake
+++ b/lib/tasks/telnet.rake
@@ -20,12 +20,14 @@ namespace :telnet do
     p 'Starting Redis subscription...'
     Redis.current.subscribe('telnet_queue') do |on|
       on.message do |channel, msg|
-        #puts "#{channel} - #{msg}"
-        alldata = JSON.parse(msg)
+        Sentry.with_scope do
+          #puts "#{channel} - #{msg}"
+          alldata = JSON.parse(msg)
 
-        alldata.each do |data|
-          telnet_string = "put #{data['name']} #{data['timestamp']} #{data['value']} device_id=#{data['tags']['device_id']} \n"
-          localhost.print telnet_string
+          alldata.each do |data|
+            telnet_string = "put #{data['name']} #{data['timestamp']} #{data['value']} device_id=#{data['tags']['device_id']} \n"
+            localhost.print telnet_string
+          end
         end
       end
     end


### PR DESCRIPTION
This ensures that the Sentry scope is reset on each new telnet or mqtt message ,for easier tracing of errors. @oscgonfer I've tested in staging and it looks good, if we could push to production when you have a sec it'd be super useful!