### PR TITLE
Move all avatars to profile_picture and ensure that profile_picture is included in responses

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
 # this file is required for errbit notifier
 class ApplicationController < ActionController::API
+    include ActionController::ImplicitRender
+    include ActionController::Helpers
 end

--- a/app/controllers/v0/application_controller.rb
+++ b/app/controllers/v0/application_controller.rb
@@ -1,3 +1,4 @@
+require_relative '../../helpers/user_helper'
 module V0
   class ApplicationController < ActionController::API
 
@@ -9,6 +10,8 @@ module V0
     include Pundit::Authorization
     include PrettyJSON
     include ErrorHandlers
+
+    helper ::UserHelper
 
     respond_to :json
 

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -1,0 +1,9 @@
+module UserHelper
+  def profile_picture_url(user)
+    if user.profile_picture.attached?
+      polymorphic_url(user.profile_picture, only_path: false)
+    else
+      ''
+    end
+  end
+end

--- a/app/views/v0/devices/_device.jbuilder
+++ b/app/views/v0/devices/_device.jbuilder
@@ -29,6 +29,9 @@ if device.owner
     json.uuid device.owner.uuid
     json.username device.owner.username
     json.avatar device.owner.avatar
+
+    json.profile_picture profile_picture_url(device.owner)
+
     json.url device.owner.url
     json.joined_at device.owner.joined_at
     json.location device.owner.location

--- a/app/views/v0/devices/index.jbuilder
+++ b/app/views/v0/devices/index.jbuilder
@@ -1,15 +1,1 @@
 json.array! @devices, partial: 'device', as: :device
-
-# json.array! @devices do |device|
-#   json.id device.id
-#   json.name device.name
-#   json.description device.description
-#   json.status device.status
-#   json.added_at device.added_at
-#   json.last_reading_at device.last_reading_at
-#   json.updated_at device.updated_at
-
-#   json.kit_id device.kit_id
-
-#   json.owner device.owner, :id, :username, :avatar, :url, :joined_at, :location, :device_ids
-# end

--- a/app/views/v0/users/_user.jbuilder
+++ b/app/views/v0/users/_user.jbuilder
@@ -11,13 +11,7 @@ json.(user,
   :updated_at
 )
 
-if user.profile_picture.attached?
-  json.profile_picture polymorphic_url(user.profile_picture, only_path: false)
-
-else
-  json.profile_picture ''
-end
-
+json.profile_picture profile_picture_url(user)
 
 if current_user and (current_user.is_admin? or current_user == user)
   json.merge! email: user.email


### PR DESCRIPTION
Needed for #166  - Currently, in various places where fablabbcn/smartcitizen-web renders a user, no profile picture is provided, leaving the default avatar showing.

I've also added a task `rake import:old_avatar_images` which will copy the old avatar across to the profile_picture for all users with an avatar who don't yet have a profile_picture. This will probably not do much in staging as it uses a different s3 bucket, but works well locally setting the credentials manually. When we run in production we should keep an eye on sidekiq to make sure the ActiveStorage AnalysisJobs complete successfully.