### PR TITLE
Add Country data for Kosovo

### DIFF
--- a/config/initializers/countries.rb
+++ b/config/initializers/countries.rb
@@ -1,0 +1,14 @@
+ISO3166::Data.register(
+  alpha2: 'XK',
+  alpha3: 'XKX',
+  name: 'Kosovo',
+  continent: "Europe",
+  currency_code: 'EUR',
+  geo: {
+    latitude: 42.602636,
+    longitude: 20.902977,
+  },
+  translations: {
+    en: 'Kosovo'
+  }
+)


### PR DESCRIPTION
A little bit of friday morning unilateral geopolitics, in order to fix https://iaac.sentry.io/issues/4488943927 (at least temporarily until the ISO grants it an official country code)