### PR TITLE
Scrub unicode before creating sentry breadcrumbs

### DIFF
--- a/app/lib/mqtt_messages_handler.rb
+++ b/app/lib/mqtt_messages_handler.rb
@@ -3,7 +3,7 @@ class MqttMessagesHandler
     crumb = Sentry::Breadcrumb.new(
       category: "MqttMessagesHandler.handle_topic",
       message: "Handling topic #{topic}",
-      data: { topic: topic, message: message }
+      data: { topic: topic, message: message.scrub }
     )
     Sentry.add_breadcrumb(crumb)
 
@@ -33,7 +33,7 @@ class MqttMessagesHandler
         message: "Parsing info message",
         data: {
           topic: topic,
-          message: message,
+          message: message.scrub,
           json: json_message,
           device_id: device.id
         }
@@ -62,7 +62,7 @@ class MqttMessagesHandler
     crumb = Sentry::Breadcrumb.new(
       category: "MqttMessagesHandler.parse_raw_readings",
       message: "Parsing raw readings",
-      data: { message: message, device_id: device_id }
+      data: { message: message.scrub, device_id: device_id }
     )
     Sentry.add_breadcrumb(crumb)
     clean_tm = message[1..-2].split(",")[0].gsub("t:", "").strip
@@ -79,7 +79,7 @@ class MqttMessagesHandler
     crumb = Sentry::Breadcrumb.new(
       category: "MqttMessagesHandler.parse_raw_readings",
       message: "Readings data constructed",
-      data: { message: message, reading: reading, device_id: device_id }
+      data: { message: message.scrub, reading: reading, device_id: device_id }
     )
     Sentry.add_breadcrumb(crumb)
 


### PR DESCRIPTION
As otherwise the `data` hash doesn't show up in the sentry UI, slightly defeating the point.