### PR TITLE
Return something sensible when searching readings for non-existent components

### DIFF
--- a/app/models/kairos.rb
+++ b/app/models/kairos.rb
@@ -26,6 +26,20 @@ class Kairos
 
     component = device.find_component_by_sensor_id(sensor_id)
 
+    unless component
+      return {
+        device_id: params[:id],
+        sensor_key:	sensor_key,
+        sensor_id: sensor_id,
+        component_id: nil,
+        rollup: params[:rollup],
+        function:	function,
+        from:	params[:from],
+        to:	params[:to],
+        sample_size:	0,
+        readings: [],
+      }
+    end
 
     metrics = [{
       tags: { device_id: params[:id] },


### PR DESCRIPTION
Fixes #275

Currently, we 500 when searching for readings for a sensor which isn't present on a device. This PR instead returns a meaningful empty response:
```
{
  "device_id": "15333",
  "sensor_key": null,
  "sensor_id": 3,
  "component_id": null,
  "rollup": "20m",
  "function": "avg",
  "from": "2023-10-25",
  "to": "2023-10-26",
  "sample_size": 0,
  "readings": []
}
```