### PR TITLE
ensure profile_picture is sent for users in search results

### DIFF
--- a/app/controllers/v0/static_controller.rb
+++ b/app/controllers/v0/static_controller.rb
@@ -118,6 +118,7 @@ module V0
           elsif s.searchable_type == 'User'
             h['username'] = s.searchable.username
             h['avatar'] = s.searchable.avatar
+            h['profile_picture'] = s.searchable.profile_picture
             h['city'] = s.searchable.city
             h['url'] = v0_user_url(s.searchable_id)
           end


### PR DESCRIPTION
Another small piece of the jigsaw for #166 - currently user icons don't show in search results as the profile_picture is not provided in the response.