### PR TITLE
use profile image url and not object in search results

### DIFF
--- a/app/controllers/v0/application_controller.rb
+++ b/app/controllers/v0/application_controller.rb
@@ -12,6 +12,7 @@ module V0
     include ErrorHandlers
 
     helper ::UserHelper
+    include ::UserHelper
 
     respond_to :json
 

--- a/app/controllers/v0/static_controller.rb
+++ b/app/controllers/v0/static_controller.rb
@@ -118,7 +118,7 @@ module V0
           elsif s.searchable_type == 'User'
             h['username'] = s.searchable.username
             h['avatar'] = s.searchable.avatar
-            h['profile_picture'] = s.searchable.profile_picture
+            h['profile_picture'] = profile_picture_url(s.searchable)
             h['city'] = s.searchable.city
             h['url'] = v0_user_url(s.searchable_id)
           end


### PR DESCRIPTION
Sorry, tiny change from my last PR on this! We need to return the profile image url, and not the object itself.