### PR TITLE
Ensure /users/:id endpoint only lists private devices when the requesting user is authorized to see them

### DIFF
--- a/app/views/v0/devices/_device.jbuilder
+++ b/app/views/v0/devices/_device.jbuilder
@@ -1,3 +1,6 @@
+with_owner = true unless local_assigns.has_key?(:with_owner)
+with_data = true unless local_assigns.has_key?(:with_data)
+
 json.(
   device,
   :id,
@@ -23,7 +26,7 @@ else
   json.merge! mac_address: '[FILTERED]'
 end
 
-if device.owner
+if with_owner && device.owner
   json.owner do
     json.id device.owner.id
     json.uuid device.owner.uuid
@@ -37,11 +40,9 @@ if device.owner
     json.location device.owner.location
     json.device_ids device.owner.cached_device_ids
   end
-else
-  json.merge! owner: nil
 end
 
-json.data device.formatted_data
+json.data device.formatted_data if with_data
 
 if device.kit
   json.kit device.kit, :id, :uuid, :slug, :name, :description, :created_at, :updated_at

--- a/app/views/v0/users/_user.jbuilder
+++ b/app/views/v0/users/_user.jbuilder
@@ -21,7 +21,9 @@ else
   json.merge! legacy_api_key: '[FILTERED]'
 end
 
-json.devices user.devices do |device|
+json.devices user.devices.filter { |d|
+  !d.is_private? || current_user == user || current_user&.is_admin?
+} do |device|
   json.id device.id
   json.uuid device.uuid
   json.is_private device.is_private

--- a/app/views/v0/users/_user.jbuilder
+++ b/app/views/v0/users/_user.jbuilder
@@ -7,7 +7,6 @@ json.(user,
   :profile_picture,
   :url,
   :location,
-  :joined_at,
   :updated_at
 )
 
@@ -23,29 +22,14 @@ end
 
 json.devices user.devices.filter { |d|
   !d.is_private? || current_user == user || current_user&.is_admin?
-} do |device|
-  json.id device.id
-  json.uuid device.uuid
-  json.is_private device.is_private
-
-  if current_user and (current_user.is_admin? or (device.owner_id and current_user.id == device.owner_id))
-    json.mac_address device.mac_address
-  else
-    json.mac_address '[FILTERED]'
-    if device.is_private?
-      next
-    end
+}.map do |device|
+  json.partial! "devices/device", device: device, with_data: false, with_owner: false
+  json.merge!(kit_id: device.kit_id)
+  if current_user == user || current_user&.is_admin?
+    json.merge!(
+      location: device.location,
+      latitude: device.latitude,
+      longitude: device.longitude,
+    )
   end
-
-  json.name device.name.present? ? device.name : nil
-  json.description device.description.present? ? device.description : nil
-  json.location device.location
-  json.latitude device.latitude
-  json.longitude device.longitude
-  json.kit_id device.kit_id
-  json.state device.state
-  json.system_tags device.system_tags
-  json.last_reading_at device.last_reading_at
-  json.added_at device.added_at.utc.iso8601
-  json.updated_at device.updated_at.utc.iso8601
 end

--- a/spec/requests/v0/users_spec.rb
+++ b/spec/requests/v0/users_spec.rb
@@ -54,6 +54,13 @@ describe V0::UsersController do
           expect(j["devices"].map { |d| d["id"] }).to include(@public_device.id)
           expect(j["devices"].map { |d| d["id"] }).not_to include(@private_device.id)
         end
+
+        it "does not include the device locations" do
+          j = api_get "users/testguy"
+          expect(j["devices"].map { |d| d["location"]}.compact).to be_empty
+          expect(j["devices"].map { |d| d["latitude"]}.compact).to be_empty
+          expect(j["devices"].map { |d| d["longitude"]}.compact).to be_empty
+        end
       end
 
       context "when the request is authenticated as the user being requested" do
@@ -62,41 +69,78 @@ describe V0::UsersController do
           expect(j["devices"].map { |d| d["id"] }).to include(@public_device.id)
           expect(j["devices"].map { |d| d["id"] }).to include(@private_device.id)
         end
+
+        it "includes the device locations" do
+          j = api_get "users/testguy?access_token=#{token.token}"
+          expect(j["devices"].map { |d| d["location"]}.compact).not_to be_empty
+          expect(j["devices"].map { |d| d["latitude"]}.compact).not_to be_empty
+          expect(j["devices"].map { |d| d["longitude"]}.compact).not_to be_empty
+        end
       end
 
       context "when the request is authenticated as a different citizen user" do
-        it "only returns public devices" do
+        let(:requesting_token) {
           requesting_user = create :user
-          requesting_token = create :access_token,
+          create :access_token,
             application: application,
             resource_owner_id: requesting_user.id
+        }
+
+        it "only returns public devices" do
           j = api_get "users/testguy?access_token=#{requesting_token.token}"
           expect(j["devices"].map { |d| d["id"] }).to include(@public_device.id)
           expect(j["devices"].map { |d| d["id"] }).not_to include(@private_device.id)
+        end
+
+        it "does not include the device locations" do
+          j = api_get "users/testguy?access_token=#{requesting_token.token}"
+          expect(j["devices"].map { |d| d["location"]}.compact).to be_empty
+          expect(j["devices"].map { |d| d["latitude"]}.compact).to be_empty
+          expect(j["devices"].map { |d| d["longitude"]}.compact).to be_empty
         end
       end
 
       context "when the request is authenticated as a different researcher user" do
-        it "only returns public devices" do
+        let(:requesting_token) {
           requesting_user = create :user, role_mask: 3
-          requesting_token = create :access_token,
+          create :access_token,
             application: application,
             resource_owner_id: requesting_user.id
+        }
+
+        it "only returns public devices" do
           j = api_get "users/testguy?access_token=#{requesting_token.token}"
           expect(j["devices"].map { |d| d["id"] }).to include(@public_device.id)
           expect(j["devices"].map { |d| d["id"] }).not_to include(@private_device.id)
         end
+
+        it "does not include the device locations" do
+          j = api_get "users/testguy?access_token=#{requesting_token.token}"
+          expect(j["devices"].map { |d| d["location"]}.compact).to be_empty
+          expect(j["devices"].map { |d| d["latitude"]}.compact).to be_empty
+          expect(j["devices"].map { |d| d["longitude"]}.compact).to be_empty
+        end
       end
 
       context "when the request is authenticated as a different admin user" do
-        it "returns all devices" do
+        let(:requesting_token) {
           requesting_user = create :user, role_mask: 5
-          requesting_token = create :access_token,
+          create :access_token,
             application: application,
             resource_owner_id: requesting_user.id
+        }
+
+        it "returns all devices" do
           j = api_get "users/testguy?access_token=#{requesting_token.token}"
           expect(j["devices"].map { |d| d["id"] }).to include(@public_device.id)
           expect(j["devices"].map { |d| d["id"] }).to include(@private_device.id)
+        end
+
+        it "includes the device locations" do
+          j = api_get "users/testguy?access_token=#{requesting_token.token}"
+          expect(j["devices"].map { |d| d["location"]}.compact).not_to be_empty
+          expect(j["devices"].map { |d| d["latitude"]}.compact).not_to be_empty
+          expect(j["devices"].map { |d| d["longitude"]}.compact).not_to be_empty
         end
       end
     end


### PR DESCRIPTION
If the current authenticated user is the user being requested, they are visible
If the current authenticated user is an admin, they are visible
If there is no current user, or the current user is a different citizen or researcher, they are not.