### PR TITLE
expose device token in /devices/:id endpoint to device owner and admins

### DIFF
--- a/app/views/v0/devices/_device.jbuilder
+++ b/app/views/v0/devices/_device.jbuilder
@@ -22,8 +22,10 @@ json.(
 
 if current_user and (current_user.is_admin? or (device.owner_id and current_user.id == device.owner_id))
   json.merge! mac_address: device.mac_address
+  json.merge! device_token: device.device_token
 else
   json.merge! mac_address: '[FILTERED]'
+  json.merge! device_token: '[FILTERED]'
 end
 
 if with_owner && device.owner

--- a/spec/requests/v0/devices_spec.rb
+++ b/spec/requests/v0/devices_spec.rb
@@ -25,7 +25,7 @@ describe V0::DevicesController do
       # expect(json[0]['name']).to eq(first.name)
       # expect(json[1]['name']).to eq(second.name)
       expect(json[0].keys).to eq(%w(id uuid name description state postprocessing
-        hardware_info system_tags user_tags is_private notify_low_battery notify_stopped_publishing last_reading_at added_at updated_at mac_address owner data kit))
+        hardware_info system_tags user_tags is_private notify_low_battery notify_stopped_publishing last_reading_at added_at updated_at mac_address device_token owner data kit))
     end
 
     describe "when not logged in" do
@@ -253,6 +253,36 @@ describe V0::DevicesController do
       it "exposes mac address to admin" do
         j = api_get "devices/#{device.id}?access_token=#{admin_token.token}"
         expect(j['mac_address']).to eq(device.mac_address)
+      end
+
+    end
+
+    describe "device_token" do
+
+      before do
+        device.device_token = "secret_token"
+        device.save!
+      end
+
+      it "filters device token from guests" do
+        j = api_get "devices/#{device.id}"
+        expect(j['device_token']).to eq('[FILTERED]')
+      end
+
+      it "filters device token from users" do
+        j = api_get "devices/#{device.id}?access_token=#{token.token}"
+        expect(j['device_token']).to eq('[FILTERED]')
+      end
+
+      it "exposes device token to device owner" do
+        device = create(:device, owner: user, device_token: "secret_token_2")
+        j = api_get "devices/#{device.id}?access_token=#{token.token}"
+        expect(j['device_token']).to eq(device.device_token)
+      end
+
+      it "exposes device token to admin" do
+        j = api_get "devices/#{device.id}?access_token=#{admin_token.token}"
+        expect(j['device_token']).to eq(device.device_token)
       end
 
     end


### PR DESCRIPTION
as requeste in #289 - I've taken the same pattern we use for the `mac_address` - we display the text '[FILTERED]' unless the logged in user is the owner or an admin.