### PR TITLE
Allow nginx to listen with SSL on port 443

### DIFF
--- a/compose/web.yml
+++ b/compose/web.yml
@@ -6,7 +6,8 @@ services:
     ports:
       - 80:80
       - 80:80/udp
-      #- 443:443
+      - 443:443
     volumes:
       - ../scripts/nginx-conf/api.smartcitizen.me.conf:/etc/nginx/conf.d/api.smartcitizen.me.conf
       - ../scripts/nginx.conf:/etc/nginx/nginx.conf
+      - ../scripts/certs:/etc/ssl:ro

--- a/scripts/nginx-conf/api.smartcitizen.me.conf
+++ b/scripts/nginx-conf/api.smartcitizen.me.conf
@@ -77,6 +77,11 @@ server {
   listen   80;
   listen   [::]:80;
 
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  ssl_certificate    /etc/ssl/star_smartcitizen_me.pem;
+  ssl_certificate_key    /etc/ssl/star_smartcitizen_me.key;
+
   try_files $uri/index.html $uri @app;
 
   location @app {


### PR DESCRIPTION
This enables strict end-to-end encryption on cloudflare.