### PR TITLE
Deferred retry of hardware_info handling when device not found

### DIFF
--- a/app/jobs/retry_mqtt_message_job.rb
+++ b/app/jobs/retry_mqtt_message_job.rb
@@ -1,22 +1,25 @@
 class RetryMQTTMessageJob < ApplicationJob
+  class RetryMessageHandlerError < RuntimeError
+  end
   queue_as :mqtt_retry
 
-  sidekiq_retry_in do |count|
-   case count
-   when 0..12
-     5.seconds
-   when 12..20 # Every 30 seconds for the first 5 minutes
-    30.seconds
-   when 20..75 # Then every minute for an hour
-     1.minute
-   else
-     :discard
-   end
-  end
+
+  retry_on RetryMessageHandlerError, attempts: 75, wait: ->(count) {
+    case count
+    when 0..12
+      5.seconds
+    when 12..20 # Every 30 seconds for the first 5 minutes
+      30.seconds
+    when 20..75 # Then every minute for an hour
+      1.minute
+    else
+      :polynomially_longer
+    end
+  }
 
   def perform(topic, message)
     result = MqttMessagesHandler.handle_topic(topic, message, false)
-    raise "Message handler returned nil, retrying" if result.nil?
+    raise RetryMessageHandlerError if result.nil?
   end
 end
 

--- a/app/jobs/retry_mqtt_message_job.rb
+++ b/app/jobs/retry_mqtt_message_job.rb
@@ -1,5 +1,17 @@
 class RetryMQTTMessageJob < ApplicationJob
-  queue_as :default
+  queue_as :mqtt_retry
+
+  sidekiq_retry_in do |count|
+   case count
+   when 0..10 # Every 30 seconds for the first 5 minutes
+    30.seconds
+   when 11..55 # Then every minute for an hour
+     1.minute
+   else
+     false # Fallback to default backoff after an hour,
+       # see https://github.com/sidekiq/sidekiq/issues/2338
+   end
+  end
 
   def perform(topic, message)
     result = MqttMessagesHandler.handle_topic(topic, message, false)

--- a/app/jobs/retry_mqtt_message_job.rb
+++ b/app/jobs/retry_mqtt_message_job.rb
@@ -1,0 +1,10 @@
+class RetryMQTTMessageJob < ApplicationJob
+  queue_as :default
+
+  def perform(topic, message)
+    result = MqttMessagesHandler.handle_topic(topic, message, false)
+    raise "Message handler returned nil, retrying" if result.nil?
+  end
+end
+
+

--- a/app/jobs/retry_mqtt_message_job.rb
+++ b/app/jobs/retry_mqtt_message_job.rb
@@ -3,13 +3,14 @@ class RetryMQTTMessageJob < ApplicationJob
 
   sidekiq_retry_in do |count|
    case count
-   when 0..10 # Every 30 seconds for the first 5 minutes
+   when 0..12
+     5.seconds
+   when 12..20 # Every 30 seconds for the first 5 minutes
     30.seconds
-   when 11..55 # Then every minute for an hour
+   when 20..75 # Then every minute for an hour
      1.minute
    else
-     false # Fallback to default backoff after an hour,
-       # see https://github.com/sidekiq/sidekiq/issues/2338
+     :discard
    end
   end
 

--- a/app/jobs/retry_mqtt_message_job.rb
+++ b/app/jobs/retry_mqtt_message_job.rb
@@ -1,21 +1,22 @@
 class RetryMQTTMessageJob < ApplicationJob
   class RetryMessageHandlerError < RuntimeError
   end
+
   queue_as :mqtt_retry
 
 
-  retry_on RetryMessageHandlerError, attempts: 75, wait: ->(count) {
+  retry_on(RetryMessageHandlerError, attempts: 75, wait: ->(count) {
     case count
     when 0..12
       5.seconds
     when 12..20 # Every 30 seconds for the first 5 minutes
       30.seconds
-    when 20..75 # Then every minute for an hour
+    else # Then every minute for an hour
       1.minute
-    else
-      :polynomially_longer
     end
-  }
+  }) do |_job, _exeception|
+    # No-op, this block ensures the exception isn't reraised and retried by Sidekiq
+  end
 
   def perform(topic, message)
     result = MqttMessagesHandler.handle_topic(topic, message, false)

--- a/app/lib/mqtt_messages_handler.rb
+++ b/app/lib/mqtt_messages_handler.rb
@@ -16,6 +16,7 @@ class MqttMessagesHandler
     # The following do NOT need a device
     if topic.to_s.include?('inventory')
       DeviceInventory.create({ report: (message rescue nil) })
+      return true
     end
 
     device = Device.find_by(device_token: device_token(topic))

--- a/app/lib/mqtt_messages_handler.rb
+++ b/app/lib/mqtt_messages_handler.rb
@@ -46,7 +46,7 @@ class MqttMessagesHandler
   end
 
   def self.handle_nil_device(topic, message, retry_on_nil_device)
-    if topic.to_s.include?("info")
+    if !topic.to_s.include?("inventory")
       retry_later(topic, message) if retry_on_nil_device
     end
   end

--- a/app/lib/mqtt_messages_handler.rb
+++ b/app/lib/mqtt_messages_handler.rb
@@ -1,5 +1,5 @@
 class MqttMessagesHandler
-  def self.handle_topic(topic, message)
+  def self.handle_topic(topic, message, retry_on_nil_device=true)
     Sentry.set_tags('mqtt-topic': topic)
 
     crumb = Sentry::Breadcrumb.new(
@@ -19,7 +19,10 @@ class MqttMessagesHandler
     end
 
     device = Device.find_by(device_token: device_token(topic))
-    return if device.nil?
+    if device.nil?
+      handle_nil_device(topic, message, retry_on_nil_device)
+      return nil
+    end
 
     if topic.to_s.include?('raw')
       handle_readings(device, parse_raw_readings(message, device.id))
@@ -40,6 +43,16 @@ class MqttMessagesHandler
       Sentry.add_breadcrumb(crumb)
       device.update_column(:hardware_info, json_message)
     end
+  end
+
+  def self.handle_nil_device(topic, message, retry_on_nil_device)
+    if topic.to_s.include?("info")
+      retry_later(topic, message) if retry_on_nil_device
+    end
+  end
+
+  def self.retry_later(topic, message)
+    RetryMQTTMessageJob.perform_later(topic, message)
   end
 
   # takes a packet and stores data

--- a/app/lib/mqtt_messages_handler.rb
+++ b/app/lib/mqtt_messages_handler.rb
@@ -43,6 +43,7 @@ class MqttMessagesHandler
       Sentry.add_breadcrumb(crumb)
       device.update_column(:hardware_info, json_message)
     end
+    return true
   end
 
   def self.handle_nil_device(topic, message, retry_on_nil_device)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,4 +1,5 @@
 Sentry.init do |config|
   config.dsn = ENV['RAVEN_DSN_URL']
   config.breadcrumbs_logger = [:sentry_logger, :active_support_logger, :http_logger]
+  config.excluded_exceptions = ["RetryMQTTMessageJob::RetryMessageHandlerError"]
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,6 +4,7 @@
 :queues:
   - default
   - mailers
+  - mqtt_retry
 
 production:
   :concurrency: 25

--- a/spec/jobs/retry_mqtt_message_job_spec.rb
+++ b/spec/jobs/retry_mqtt_message_job_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe RetryMQTTMessageJob, type: :job do
+  it "retries the mqtt ingest with the given topic and message, and with automatic retries disabled" do
+    topic = "topic/1/2/3"
+    message = '{"foo": "bar", "test": "message"}'
+    expect(MqttMessagesHandler).to receive(:handle_topic).with(topic, message, false).and_return(true)
+    RetryMQTTMessageJob.perform_now(topic, message)
+  end
+
+  it "raises an error if the handler returns nil" do
+    topic = "topic/1/2/3"
+    message = '{"foo": "bar", "test": "message"}'
+    expect(MqttMessagesHandler).to receive(:handle_topic).with(topic, message, false).and_return(nil)
+    expect {
+      RetryMQTTMessageJob.perform_now(topic, message)
+    }.to raise_error
+  end
+end

--- a/spec/jobs/retry_mqtt_message_job_spec.rb
+++ b/spec/jobs/retry_mqtt_message_job_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe RetryMQTTMessageJob, type: :job do
+  include ActiveJob::TestHelper
+
   it "retries the mqtt ingest with the given topic and message, and with automatic retries disabled" do
     topic = "topic/1/2/3"
     message = '{"foo": "bar", "test": "message"}'
@@ -8,12 +10,12 @@ RSpec.describe RetryMQTTMessageJob, type: :job do
     RetryMQTTMessageJob.perform_now(topic, message)
   end
 
-  it "raises an error if the handler returns nil" do
+  it "retries if the handler returns nil" do
     topic = "topic/1/2/3"
     message = '{"foo": "bar", "test": "message"}'
-    expect(MqttMessagesHandler).to receive(:handle_topic).with(topic, message, false).and_return(nil)
-    expect {
-      RetryMQTTMessageJob.perform_now(topic, message)
-    }.to raise_error
+    expect(MqttMessagesHandler).to receive(:handle_topic).with(topic, message, false).and_return(nil, nil, true)
+    assert_performed_jobs 3 do
+      RetryMQTTMessageJob.perform_later(topic, message)
+    end
   end
 end

--- a/spec/lib/mqtt_messages_handler_spec.rb
+++ b/spec/lib/mqtt_messages_handler_spec.rb
@@ -243,9 +243,19 @@ RSpec.describe MqttMessagesHandler do
       expect(orphan_device.reload.device_handshake).to be true
     end
 
-    it 'does not handle bad topic' do
+    it 'defers messages with unknown device tokens if retry flag is true' do
       expect(device.hardware_info["id"]).to eq(47)
+      expect(RetryMQTTMessageJob).to receive(:perform_later).with(@hardware_info_packet_bad.topic, @hardware_info_packet_bad.payload)
       MqttMessagesHandler.handle_topic(@hardware_info_packet_bad.topic, @hardware_info_packet_bad.payload)
+      device.reload
+      expect(device.hardware_info["id"]).to eq(47)
+      expect(@hardware_info_packet_bad.payload).to_not eq((device.hardware_info.to_json))
+    end
+
+    it 'does not defer messages with unknown device tokens if retry flag is false' do
+      expect(device.hardware_info["id"]).to eq(47)
+      expect(RetryMQTTMessageJob).not_to receive(:perform_later).with(@hardware_info_packet_bad.topic, @hardware_info_packet_bad.payload)
+      MqttMessagesHandler.handle_topic(@hardware_info_packet_bad.topic, @hardware_info_packet_bad.payload, false)
       device.reload
       expect(device.hardware_info["id"]).to eq(47)
       expect(@hardware_info_packet_bad.payload).to_not eq((device.hardware_info.to_json))


### PR DESCRIPTION
Since we deployed the devices refactor, a slightly subtle bug (#314) has emerged: if a device sends the hardware_info packet before the user has completed registration, the device is not found, the info is not saved, and therefore the device information in the UI is incomplete. This (hopefully, I like to test on staging with a real device) fixes this by relying on Sidekiq's built in error handling functionality to retry the hardware_info message (with backoff) in the event that no device corresponds to the given key. Sidekiq defaults to 25 retries with backoff (corresponding to about 3 weeks of elapsed time between the first and the last try), which should be sufficient: https://docs.gitlab.com/ee/development/sidekiq/.