### PR TITLE
Forwarding of device data

### DIFF
--- a/app/controllers/v0/forwarding_controller.rb
+++ b/app/controllers/v0/forwarding_controller.rb
@@ -1,0 +1,20 @@
+module V0
+  class ForwardingController < ApplicationController
+    after_action :verify_authorized, except: :authorize
+    def authorize
+      topic = params[:topic]
+      username = params[:username]
+      token = topic && get_forwarding_token(topic)
+      authorized = token && username && User.forwarding_subscription_authorized?(token, username)
+      render json: { result: authorized ? "allow" : "ignore" }
+    end
+
+    private
+
+    def get_forwarding_token(topic)
+      match = topic.match(/forward\/([^\/]+)\//)
+      match && match[1]
+    end
+  end
+end
+

--- a/app/controllers/v0/forwarding_controller.rb
+++ b/app/controllers/v0/forwarding_controller.rb
@@ -6,7 +6,7 @@ module V0
       username = params[:username]
       token = topic && get_forwarding_token(topic)
       authorized = token && username && User.forwarding_subscription_authorized?(token, username)
-      render json: { result: authorized ? "allow" : "ignore" }
+      render json: { result: authorized ? "allow" : "deny" }
     end
 
     private

--- a/app/controllers/v0/readings_controller.rb
+++ b/app/controllers/v0/readings_controller.rb
@@ -37,7 +37,7 @@ module V0
 
       if request.headers['X-SmartCitizenData']
         MQTTClientFactory.create_client({clean_session: true, client_id: nil}) do |mqtt_client|
-          storer = RawStorer.new(mqtt_client)
+          storer = RawStorer.new(mqtt_client, self)
           JSON.parse(request.headers['X-SmartCitizenData']).each do |raw_reading|
             mac = request.headers['X-SmartCitizenMacADDR']
             version = request.headers['X-SmartCitizenVersion']

--- a/app/controllers/v0/readings_controller.rb
+++ b/app/controllers/v0/readings_controller.rb
@@ -36,13 +36,14 @@ module V0
     def legacy_create
 
       if request.headers['X-SmartCitizenData']
-        JSON.parse(request.headers['X-SmartCitizenData']).each do |raw_reading|
-
-          mac = request.headers['X-SmartCitizenMacADDR']
-          version = request.headers['X-SmartCitizenVersion']
-          ip = (request.headers['X-SmartCitizenIP'] || request.remote_ip)
-
-          RawStorer.new(raw_reading,mac,version,ip)
+        MQTTClientFactory.create_client({clean_session: true, client_id: nil}) do |mqtt_client|
+          storer = RawStorer.new(mqtt_client)
+          JSON.parse(request.headers['X-SmartCitizenData']).each do |raw_reading|
+            mac = request.headers['X-SmartCitizenMacADDR']
+            version = request.headers['X-SmartCitizenVersion']
+            ip = (request.headers['X-SmartCitizenIP'] || request.remote_ip)
+            storer.store(raw_reading,mac,version,ip)
+          end
         end
       end
 

--- a/app/jobs/retry_mqtt_message_job.rb
+++ b/app/jobs/retry_mqtt_message_job.rb
@@ -19,9 +19,26 @@ class RetryMQTTMessageJob < ApplicationJob
   end
 
   def perform(topic, message)
-    result = MqttMessagesHandler.handle_topic(topic, message, false)
-    raise RetryMessageHandlerError if result.nil?
+    begin
+      result = handler.handle_topic(topic, message, false)
+      raise RetryMessageHandlerError if result.nil?
+    ensure
+      disconnect_mqtt
+    end
+  end
+
+  private
+
+  def handler
+    @handler ||= MqttMessagesHandler.new(mqtt_client)
+  end
+
+  def mqtt_client
+    @mqtt_client ||= MQTTClientFactory.create_client({clean_session: true, client_id: nil })
+  end
+
+  def disconnect_mqtt
+    @mqtt_client&.disconnect
   end
 end
-
 

--- a/app/jobs/send_to_datastore_job.rb
+++ b/app/jobs/send_to_datastore_job.rb
@@ -2,15 +2,28 @@ class SendToDatastoreJob < ApplicationJob
   queue_as :default
 
   def perform(data_param, device_id)
-
-    @device = Device.includes(:components).find(device_id)
-
-    the_data = JSON.parse(data_param)
-    the_data.sort_by {|a| a['recorded_at']}.reverse.each_with_index do |reading, index|
-      # move to async method call
-      do_update = index == 0
-      Storer.new(@device, reading, do_update)
+    begin
+      @device = Device.includes(:components).find(device_id)
+      the_data = JSON.parse(data_param)
+      the_data.sort_by {|a| a['recorded_at']}.reverse.each_with_index do |reading, index|
+        # move to async method call
+        do_update = index == 0
+        storer.store(@device, reading, do_update)
+      end
+    ensure
+      disconnect_mqtt
     end
+  end
 
+  def storer
+    @storer ||= Storer.new(mqtt_client)
+  end
+
+  def mqtt_client
+    @mqtt_client ||= MQTTClientFactory.create_client({clean_session: true, client_id: nil })
+  end
+
+  def disconnect_mqtt
+    @mqtt_client&.disconnect
   end
 end

--- a/app/jobs/send_to_datastore_job.rb
+++ b/app/jobs/send_to_datastore_job.rb
@@ -16,7 +16,7 @@ class SendToDatastoreJob < ApplicationJob
   end
 
   def storer
-    @storer ||= Storer.new(mqtt_client)
+    @storer ||= Storer.new(mqtt_client, ActionController::Base.new.view_context)
   end
 
   def mqtt_client

--- a/app/lib/mqtt_client_factory.rb
+++ b/app/lib/mqtt_client_factory.rb
@@ -1,0 +1,33 @@
+module MQTTClientFactory
+  def self.create_client(args={}, &block)
+    host          = args.fetch(:host, default_host)
+    port          = args.fetch(:port, default_port)
+    clean_sesion  = args.fetch(:clean_session, default_clean_session)
+    client_id     = args.fetch(:client_id, default_client_id)
+    ssl           = args.fetch(:ssl, default_ssl)
+    MQTT::Client.connect(
+      { host: host, port: port, clean_session: clean_sesion, client_id: client_id, ssl: ssl},
+      &block
+    )
+  end
+
+  def self.default_host
+    ENV.fetch('MQTT_HOST', 'mqtt')
+  end
+
+  def self.default_port
+    ENV.fetch('MQTT_PORT', "1883").to_i
+  end
+
+  def self.default_clean_session
+    ENV.fetch('MQTT_CLEAN_SESSION', "true") == "true"
+  end
+
+  def self.default_client_id
+    ENV.fetch('MQTT_CLIENT_ID', nil)
+  end
+
+  def self.default_ssl
+    ENV.fetch('MQTT_SSL', "false") == "true"
+  end
+end

--- a/app/lib/mqtt_forwarder.rb
+++ b/app/lib/mqtt_forwarder.rb
@@ -1,0 +1,20 @@
+class MQTTForwarder
+  def initialize(client, prefix="forward/devices", suffix="readings")
+    @client = client
+    @prefix = prefix
+    @suffix = suffix
+  end
+
+  def forward_reading(token, device_id, reading)
+    topic = topic_path(token, device_id)
+    client.publish(topic, reading)
+  end
+
+  private
+
+  def topic_path(token, device_id)
+    [prefix, token, device_id, suffix].join("/")
+  end
+
+  attr_reader :client, :prefix, :suffix
+end

--- a/app/lib/mqtt_forwarder.rb
+++ b/app/lib/mqtt_forwarder.rb
@@ -1,5 +1,5 @@
 class MQTTForwarder
-  def initialize(client, prefix="forward/devices", suffix="readings")
+  def initialize(client)
     @client = client
     @prefix = prefix
     @suffix = suffix
@@ -13,7 +13,7 @@ class MQTTForwarder
   private
 
   def topic_path(token, device_id)
-    [prefix, token, device_id, suffix].join("/")
+    ["/forward", token, "device", device_id, "readings"].join("/")
   end
 
   attr_reader :client, :prefix, :suffix

--- a/app/lib/mqtt_messages_handler.rb
+++ b/app/lib/mqtt_messages_handler.rb
@@ -53,7 +53,7 @@ class MqttMessagesHandler
   end
 
   def handle_nil_device(topic, message, retry_on_nil_device)
-    if !topic.to_s.include?("inventory")
+    if !topic.to_s.include?("inventory") && !topic.to_s.include?("bridge")
       retry_later(topic, message) if retry_on_nil_device
     end
   end

--- a/app/lib/mqtt_messages_handler.rb
+++ b/app/lib/mqtt_messages_handler.rb
@@ -141,6 +141,6 @@ class MqttMessagesHandler
 
 
   def storer
-    @storer ||= Storer.new(mqtt_client)
+    @storer ||= Storer.new(mqtt_client, ActionController::Base.new.view_context)
   end
 end

--- a/app/lib/mqtt_messages_handler.rb
+++ b/app/lib/mqtt_messages_handler.rb
@@ -1,5 +1,10 @@
 class MqttMessagesHandler
-  def self.handle_topic(topic, message, retry_on_nil_device=true)
+
+  def initialize(mqtt_client)
+    @mqtt_client = mqtt_client
+  end
+
+  def handle_topic(topic, message, retry_on_nil_device=true)
     Sentry.set_tags('mqtt-topic': topic)
 
     crumb = Sentry::Breadcrumb.new(
@@ -47,23 +52,23 @@ class MqttMessagesHandler
     return true
   end
 
-  def self.handle_nil_device(topic, message, retry_on_nil_device)
+  def handle_nil_device(topic, message, retry_on_nil_device)
     if !topic.to_s.include?("inventory")
       retry_later(topic, message) if retry_on_nil_device
     end
   end
 
-  def self.retry_later(topic, message)
+  def retry_later(topic, message)
     RetryMQTTMessageJob.perform_later(topic, message)
   end
 
   # takes a packet and stores data
-  def self.handle_readings(device, message)
+  def handle_readings(device, message)
     data = self.data(message)
     return if data.nil? or data&.empty?
 
     data.each do |reading|
-      Storer.new(device, reading)
+      storer.store(device, reading)
     end
   rescue Exception => e
     Sentry.capture_exception(e)
@@ -73,7 +78,7 @@ class MqttMessagesHandler
   end
 
   # takes a raw packet and converts into JSON
-  def self.parse_raw_readings(message, device_id=nil)
+  def parse_raw_readings(message, device_id=nil)
     crumb = Sentry::Breadcrumb.new(
       category: "MqttMessagesHandler.parse_raw_readings",
       message: "Parsing raw readings",
@@ -101,7 +106,7 @@ class MqttMessagesHandler
     JSON[reading]
   end
 
-  def self.handshake_device(topic)
+  def handshake_device(topic)
     orphan_device = OrphanDevice.find_by(device_token: device_token(topic))
     return if orphan_device.nil?
     orphan_device.update!(device_handshake: true)
@@ -111,12 +116,12 @@ class MqttMessagesHandler
   end
 
   # takes a packet and returns 'device token' from topic
-  def self.device_token(topic)
+  def device_token(topic)
     topic[/device\/sck\/(.*?)\//m, 1].to_s
   end
 
   # takes a packet and returns 'data' from payload
-  def self.data(message)
+  def data(message)
     # TODO: what if message is empty?
     if message
       begin
@@ -127,5 +132,15 @@ class MqttMessagesHandler
     else
       raise "No data(message)"
     end
+  end
+
+
+  private
+
+  attr_reader :mqtt_client
+
+
+  def storer
+    @storer ||= Storer.new(mqtt_client)
   end
 end

--- a/app/models/concerns/message_forwarding.rb
+++ b/app/models/concerns/message_forwarding.rb
@@ -1,0 +1,15 @@
+module MessageForwarding
+
+  extend ActiveSupport::Concern
+
+  def forward_reading(device, reading)
+    forwarder = MQTTForwarder.new(mqtt_client)
+    forwarder.forward_reading(device.forwarding_token, device.id, reading) if device.forward_readings?
+  end
+
+  private
+
+  def mqtt_client
+    raise NotImplementedError
+  end
+end

--- a/app/models/concerns/message_forwarding.rb
+++ b/app/models/concerns/message_forwarding.rb
@@ -4,12 +4,28 @@ module MessageForwarding
 
   def forward_reading(device, reading)
     forwarder = MQTTForwarder.new(mqtt_client)
-    forwarder.forward_reading(device.forwarding_token, device.id, reading) if device.forward_readings?
+    payload = payload_for(device, reading)
+    forwarder.forward_reading(device.forwarding_token, device.id, payload) if device.forward_readings?
+  end
+
+  def payload_for(device, reading)
+    renderer.render(
+      partial: "v0/devices/device",
+      locals: {
+        device: device.reload,
+        current_user: nil,
+        slim_owner: true
+      }
+    )
   end
 
   private
 
   def mqtt_client
+    raise NotImplementedError
+  end
+
+  def renderer
     raise NotImplementedError
   end
 end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -271,6 +271,14 @@ class Device < ActiveRecord::Base
     hardware_slug_override || [hardware_type.downcase, hardware_version&.gsub(".", ",")].compact.join(":")
   end
 
+  def forward_readings?
+    owner.forward_device_readings?
+  end
+
+  def forwarding_token
+    owner.forwarding_token
+  end
+
   private
 
     def set_state

--- a/app/models/raw_storer.rb
+++ b/app/models/raw_storer.rb
@@ -3,9 +3,13 @@
 # ingest raw data posted by Devices into Kairos and Postgres (backup purposes).
 
 class RawStorer
+  include MessageForwarding
 
-  def initialize data, mac, version, ip, raise_errors=false
+  def initialize(mqtt_client)
+    @mqtt_client = mqtt_client
+  end
 
+  def store data, mac, version, ip, raise_errors=false
     success = true
 
     begin
@@ -62,6 +66,7 @@ class RawStorer
         device.update_columns(last_reading_at: parsed_ts, data: sql_data, state: 'has_published')
       end
 
+      forward_reading(device, data)
     rescue Exception => e
 
       success = false
@@ -74,7 +79,10 @@ class RawStorer
       rescue
       end
     end
-
   end
+
+  private
+
+  attr_reader :mqtt_client
 
 end

--- a/app/models/raw_storer.rb
+++ b/app/models/raw_storer.rb
@@ -5,8 +5,9 @@
 class RawStorer
   include MessageForwarding
 
-  def initialize(mqtt_client)
+  def initialize(mqtt_client, renderer)
     @mqtt_client = mqtt_client
+    @renderer = renderer
   end
 
   def store data, mac, version, ip, raise_errors=false
@@ -75,7 +76,7 @@ class RawStorer
 
     if !Rails.env.test? and device
       begin
-        Redis.current.publish("data-received", ActionController::Base.new.view_context.render( partial: "v0/devices/device", locals: {device: @device, current_user: nil}))
+        Redis.current.publish("data-received", renderer.render( partial: "v0/devices/device", locals: {device: @device, current_user: nil}))
       rescue
       end
     end
@@ -83,6 +84,6 @@ class RawStorer
 
   private
 
-  attr_reader :mqtt_client
+  attr_reader :mqtt_client, :renderer
 
 end

--- a/app/models/storer.rb
+++ b/app/models/storer.rb
@@ -2,8 +2,9 @@ class Storer
   include DataParser::Storer
   include MessageForwarding
 
-  def initialize(mqtt_client)
+  def initialize(mqtt_client, renderer)
     @mqtt_client = mqtt_client
+    @renderer = renderer
   end
 
   def store device, reading, do_update = true
@@ -51,13 +52,13 @@ class Storer
   def ws_publish(device)
     return if Rails.env.test? or device.blank?
     begin
-      Redis.current.publish("data-received", ActionController::Base.new.view_context.render( partial: "v0/devices/device", locals: {device: device, current_user: nil}))
+      Redis.current.publish("data-received", renderer.render( partial: "v0/devices/device", locals: {device: device, current_user: nil}))
     rescue
     end
   end
 
   private
 
-  attr_reader :mqtt_client
+  attr_reader :mqtt_client, :renderer
 
 end

--- a/app/models/storer.rb
+++ b/app/models/storer.rb
@@ -1,14 +1,22 @@
 class Storer
   include DataParser::Storer
+  include MessageForwarding
 
-  def initialize device, reading, do_update = true
-    @device = device
+  def initialize(mqtt_client)
+    @mqtt_client = mqtt_client
+  end
+
+  def store device, reading, do_update = true
     begin
-      parsed_reading = Storer.parse_reading(@device, reading)
-
+      parsed_reading = Storer.parse_reading(device, reading)
       kairos_publish(parsed_reading[:_data])
 
-      update_device(parsed_reading[:parsed_ts], parsed_reading[:sql_data]) if do_update
+      if do_update
+        update_device(device, parsed_reading[:parsed_ts], parsed_reading[:sql_data])
+        ws_publish(device)
+      end
+
+      forward_reading(device, reading)
 
     rescue Exception => e
       Sentry.capture_exception(e)
@@ -18,21 +26,20 @@ class Storer
     raise e unless e.nil?
   end
 
-  def update_device(parsed_ts, sql_data)
+  def update_device(device, parsed_ts, sql_data)
     return if parsed_ts <= Time.at(0)
 
-    if @device.last_reading_at.present?
-      # Comparison errors if @device.last_reading_at is nil (new devices).
+    if device.last_reading_at.present?
+      # Comparison errors if device.last_reading_at is nil (new devices).
       # Devices can post multiple readings, in a non-sorted order.
       # Do not update data with an older timestamp.
-      return if parsed_ts < @device.last_reading_at
+      return if parsed_ts < device.last_reading_at
     end
 
-    sql_data = @device.data.present? ? @device.data.merge(sql_data) : sql_data
-    @device.update_columns(last_reading_at: parsed_ts, data: sql_data, state: 'has_published')
+    sql_data = device.data.present? ? device.data.merge(sql_data) : sql_data
+    device.update_columns(last_reading_at: parsed_ts, data: sql_data, state: 'has_published')
     sensor_ids = sql_data.select { |k, v| k.is_a?(Integer) }.keys.compact.uniq
-    @device.update_component_timestamps(parsed_ts, sensor_ids)
-    ws_publish()
+    device.update_component_timestamps(parsed_ts, sensor_ids)
   end
 
   def kairos_publish(reading_data)
@@ -41,11 +48,16 @@ class Storer
     Redis.current.publish('telnet_queue', reading_data.to_json)
   end
 
-  def ws_publish()
-    return if Rails.env.test? or @device.blank?
+  def ws_publish(device)
+    return if Rails.env.test? or device.blank?
     begin
-      Redis.current.publish("data-received", ActionController::Base.new.view_context.render( partial: "v0/devices/device", locals: {device: @device, current_user: nil}))
+      Redis.current.publish("data-received", ActionController::Base.new.view_context.render( partial: "v0/devices/device", locals: {device: device, current_user: nil}))
     rescue
     end
   end
+
+  private
+
+  attr_reader :mqtt_client
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,6 +39,11 @@ class User < ActiveRecord::Base
 
   before_create :generate_legacy_api_key
 
+
+  def self.forwarding_subscription_authorized?(token, username)
+    User.find_by_forwarding_token(token)&.forwarding_username == username
+  end
+
   def self.ransackable_attributes(auth_object = nil)
     [ "city", "country_code", "id", "username", "uuid", "created_at", "updated_at"]
   end
@@ -148,8 +153,11 @@ class User < ActiveRecord::Base
     !!forwarding_token
   end
 
-  def regenerate_forwarding_token!
-    self.forwarding_token = SecureRandom.urlsafe_base64(12) if self.is_admin_or_researcher?
+  def regenerate_forwarding_tokens!
+    if is_admin_or_researcher?
+      self.forwarding_token = SecureRandom.urlsafe_base64(12)
+      self.forwarding_username = SecureRandom.urlsafe_base64(12)
+    end
   end
 
 private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -144,6 +144,14 @@ class User < ActiveRecord::Base
     end
   end
 
+  def forward_device_readings?
+    !!forwarding_token
+  end
+
+  def regenerate_forwarding_token!
+    self.forwarding_token = SecureRandom.urlsafe_base64(12) if self.is_admin_or_researcher?
+  end
+
 private
 
   def check_if_users_have_valid_email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
     resources :users
     resources :password_resets, only: [:show, :create, :update]
     resources :oauth_applications, path: 'applications'
+    get :forward, to: "forwarding#authorize"
 
     resources :me, only: [:index] do
       patch 'avatar' => 'uploads#create', on: :collection

--- a/db/migrate/20240423162838_add_forwarding_token_to_users.rb
+++ b/db/migrate/20240423162838_add_forwarding_token_to_users.rb
@@ -1,0 +1,5 @@
+class AddForwardingTokenToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :forwarding_token, :string
+  end
+end

--- a/db/migrate/20240512132257_add_forwarding_username_to_users.rb
+++ b/db/migrate/20240512132257_add_forwarding_username_to_users.rb
@@ -1,0 +1,6 @@
+class AddForwardingUsernameToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :forwarding_username, :string
+    add_index :users, :forwarding_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_04_23_162838) do
+ActiveRecord::Schema.define(version: 2024_05_12_132257) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "adminpack"
@@ -297,6 +297,8 @@ ActiveRecord::Schema.define(version: 2024_04_23_162838) do
     t.integer "cached_device_ids", array: true
     t.string "workflow_state"
     t.string "forwarding_token"
+    t.string "forwarding_username"
+    t.index ["forwarding_token"], name: "index_users_on_forwarding_token"
     t.index ["legacy_api_key"], name: "index_users_on_legacy_api_key", unique: true
     t.index ["workflow_state"], name: "index_users_on_workflow_state"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_03_18_171656) do
+ActiveRecord::Schema.define(version: 2024_04_23_162838) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "adminpack"
@@ -296,6 +296,7 @@ ActiveRecord::Schema.define(version: 2024_03_18_171656) do
     t.jsonb "old_data"
     t.integer "cached_device_ids", array: true
     t.string "workflow_state"
+    t.string "forwarding_token"
     t.index ["legacy_api_key"], name: "index_users_on_legacy_api_key", unique: true
     t.index ["workflow_state"], name: "index_users_on_workflow_state"
   end

--- a/lib/tasks/mqtt_subscriber.rake
+++ b/lib/tasks/mqtt_subscriber.rake
@@ -20,7 +20,7 @@ namespace :mqtt do
     mqtt_log.info("ssl: #{mqtt_ssl}")
 
     begin
-      MQTT::Client.connect(
+      MQTTClientFactory.create_client(
         :host => mqtt_host,
         :port => mqtt_port,
         :clean_session => mqtt_clean_session,
@@ -30,6 +30,8 @@ namespace :mqtt do
 
         mqtt_log.info "Connected to #{client.host}"
         mqtt_log.info "Using clean_session setting: #{client.clean_session}"
+
+        message_handler = MqttMessagesHandler.new(client)
 
         client.subscribe(*mqtt_topics.flat_map { |topic|
           topic = topic == "" ? topic : topic + "/"
@@ -46,7 +48,7 @@ namespace :mqtt do
           Sentry.with_scope do
             begin
               time = Benchmark.measure do
-                MqttMessagesHandler.handle_topic(topic, message)
+                message_handler.handle_topic(topic, message)
               end
               mqtt_log.info "Processed MQTT message in #{time}"
               mqtt_log.info "MQTT queue length: #{client.queue_length}"

--- a/spec/jobs/retry_mqtt_message_job_spec.rb
+++ b/spec/jobs/retry_mqtt_message_job_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe RetryMQTTMessageJob, type: :job do
     expect(mqtt_message_handler).to have_received(:handle_topic).with(topic, message, false)
   end
 
-  it "disconnects the cliient when done" do
+  it "disconnects the client when done" do
     RetryMQTTMessageJob.perform_now(topic, message)
     expect(mqtt_client).to have_received(:disconnect)
   end

--- a/spec/jobs/retry_mqtt_message_job_spec.rb
+++ b/spec/jobs/retry_mqtt_message_job_spec.rb
@@ -3,19 +3,61 @@ require 'rails_helper'
 RSpec.describe RetryMQTTMessageJob, type: :job do
   include ActiveJob::TestHelper
 
-  it "retries the mqtt ingest with the given topic and message, and with automatic retries disabled" do
-    topic = "topic/1/2/3"
-    message = '{"foo": "bar", "test": "message"}'
-    expect(MqttMessagesHandler).to receive(:handle_topic).with(topic, message, false).and_return(true)
-    RetryMQTTMessageJob.perform_now(topic, message)
+  let(:mqtt_client) {
+    double(:mqtt_client).tap do |mqtt_client|
+      allow(mqtt_client).to receive(:disconnect)
+    end
+  }
+
+  let(:handler_results) { [true] }
+
+  let(:mqtt_message_handler) {
+    double(:mqtt_message_handler).tap do |mqtt_message_handler|
+      allow(mqtt_message_handler).to receive(:handle_topic).and_return(*handler_results)
+    end
+  }
+
+  let(:topic) { "topic/1/2/3" }
+
+  let(:message) { '{"foo": "bar", "test": "message"}' }
+
+  before do
+    allow(MQTTClientFactory).to receive(:create_client).and_return(mqtt_client)
+    allow(MqttMessagesHandler).to receive(:new).and_return(mqtt_message_handler)
   end
 
-  it "retries if the handler returns nil" do
-    topic = "topic/1/2/3"
-    message = '{"foo": "bar", "test": "message"}'
-    expect(MqttMessagesHandler).to receive(:handle_topic).with(topic, message, false).and_return(nil, nil, true)
-    assert_performed_jobs 3 do
-      RetryMQTTMessageJob.perform_later(topic, message)
+  it "creates an MQTT client, overriding clean_session to true and the client_id to nil" do
+    RetryMQTTMessageJob.perform_now(topic, message)
+    expect(MQTTClientFactory).to have_received(:create_client).with({clean_session: true, client_id: nil })
+  end
+
+  it "creates an MQTTMessagesHandler, passing the client" do
+    RetryMQTTMessageJob.perform_now(topic, message)
+    expect(MqttMessagesHandler).to have_received(:new).with(mqtt_client)
+  end
+
+  it "retries the mqtt ingest with the given topic and message, and with automatic retries disabled" do
+    RetryMQTTMessageJob.perform_now(topic, message)
+    expect(mqtt_message_handler).to have_received(:handle_topic).with(topic, message, false)
+  end
+
+  it "disconnects the cliient when done" do
+    RetryMQTTMessageJob.perform_now(topic, message)
+    expect(mqtt_client).to have_received(:disconnect)
+  end
+
+  context "when the handler returns nil" do
+    let(:handler_results) { [nil, nil, true] }
+
+    it "retries when the handler returns nil" do
+      assert_performed_jobs 3 do
+        RetryMQTTMessageJob.perform_later(topic, message)
+      end
+    end
+
+    it "closes the mqtt connection" do
+      RetryMQTTMessageJob.perform_now(topic, message)
+      expect(mqtt_client).to have_received(:disconnect)
     end
   end
 end

--- a/spec/lib/mqtt_messages_handler_spec.rb
+++ b/spec/lib/mqtt_messages_handler_spec.rb
@@ -7,6 +7,18 @@ RSpec.describe MqttMessagesHandler do
 
   let(:device_inventory) { create(:device_inventory, report: '{"random_property": "random_result"}') }
 
+
+  let(:mqtt_client) {
+    double(:mqtt_client).tap do |mqtt_client|
+      allow(mqtt_client).to receive(:publish)
+    end
+  }
+
+  subject(:message_handler) {
+    MqttMessagesHandler.new(mqtt_client)
+  }
+
+
   before do
     device.components << component
     create(:sensor, id: 13, default_key: "key13")
@@ -48,13 +60,13 @@ RSpec.describe MqttMessagesHandler do
 
   describe '#device_token' do
     it 'returns device_token from topic' do
-      expect(MqttMessagesHandler.device_token(@packet.topic)).to eq(device.device_token)
+      expect(message_handler.device_token(@packet.topic)).to eq(device.device_token)
     end
   end
 
   describe '#data' do
     it 'returns parsed data from payload' do
-      expect(MqttMessagesHandler.data(@packet.payload)).to match_array(@data)
+      expect(message_handler.data(@packet.payload)).to match_array(@data)
     end
   end
 
@@ -90,7 +102,7 @@ RSpec.describe MqttMessagesHandler do
             }
           }].to_json
         )
-        MqttMessagesHandler.handle_topic(@packet.topic, @packet.payload)
+        message_handler.handle_topic(@packet.topic, @packet.payload)
       end
 
       it 'handshakes the device if an orphan device exists' do
@@ -102,7 +114,7 @@ RSpec.describe MqttMessagesHandler do
             onboarding_session: orphan_device.onboarding_session
           }.to_json
         )
-        MqttMessagesHandler.handle_topic(@packet.topic, @packet.payload)
+        message_handler.handle_topic(@packet.topic, @packet.payload)
         expect(orphan_device.reload.device_handshake).to be true
       end
 
@@ -118,24 +130,24 @@ RSpec.describe MqttMessagesHandler do
             }
           }].to_json
         )
-        MqttMessagesHandler.handle_topic(@packet.topic, @hardware_info_packet.payload)
+        message_handler.handle_topic(@packet.topic, @hardware_info_packet.payload)
       end
 
       it 'defers messages with unknown device tokens if retry flag is true' do
         expect(RetryMQTTMessageJob).to receive(:perform_later).with(@invalid_packet.topic, @invalid_packet.payload)
-        MqttMessagesHandler.handle_topic(@invalid_packet.topic, @invalid_packet.payload)
+        message_handler.handle_topic(@invalid_packet.topic, @invalid_packet.payload)
       end
 
       it 'does not defer messages with unknown device tokens if retry flag is false' do
         expect(RetryMQTTMessageJob).not_to receive(:perform_later).with(@invalid_packet.topic, @invalid_packet.payload)
-        MqttMessagesHandler.handle_topic(@invalid_packet.topic, @invalid_packet.payload, false)
+        message_handler.handle_topic(@invalid_packet.topic, @invalid_packet.payload, false)
       end
 
       context 'invalid packet' do
         it 'it notifies Sentry' do
           allow(Sentry).to receive(:capture_exception)
           expect(Kairos).not_to receive(:http_post_to)
-          MqttMessagesHandler.handle_topic(@invalid_packet.topic, @invalid_packet.payload)
+          message_handler.handle_topic(@invalid_packet.topic, @invalid_packet.payload)
           #expect(Sentry).to have_received(:capture_exception).with(RuntimeError)
         end
       end
@@ -169,7 +181,7 @@ RSpec.describe MqttMessagesHandler do
         }].to_json
       )
 
-      MqttMessagesHandler.handle_topic("device/sck/#{device.device_token}/readings/raw", the_data)
+      message_handler.handle_topic("device/sck/#{device.device_token}/readings/raw", the_data)
 
       # TODO: we should expect that a new Storer object should contain the correct, processed readings
       #expect(Storer).to receive(:new)
@@ -184,7 +196,7 @@ RSpec.describe MqttMessagesHandler do
           onboarding_session: orphan_device.onboarding_session
         }.to_json
       )
-      MqttMessagesHandler.handle_topic("device/sck/#{device.device_token}/readings/raw", the_data)
+      message_handler.handle_topic("device/sck/#{device.device_token}/readings/raw", the_data)
       expect(orphan_device.reload.device_handshake).to be true
     end
   end
@@ -197,7 +209,7 @@ RSpec.describe MqttMessagesHandler do
           onboarding_session: orphan_device.onboarding_session
         }.to_json
       )
-      MqttMessagesHandler.handle_topic(
+      message_handler.handle_topic(
         "device/sck/#{orphan_device.device_token}/hello",
         'content ignored by MqttMessagesHandler\#hello'
       )
@@ -211,21 +223,21 @@ RSpec.describe MqttMessagesHandler do
       # This creates a new device_inventory item
       expect(@inventory_packet.payload).to eq((device_inventory.report.to_json))
       expect(DeviceInventory.count).to eq(1)
-      MqttMessagesHandler.handle_topic(@inventory_packet.topic, @inventory_packet.payload)
+      message_handler.handle_topic(@inventory_packet.topic, @inventory_packet.payload)
       expect(DeviceInventory.last.report["random_property"]).to eq('random_result')
       expect(DeviceInventory.count).to eq(2)
     end
 
     it 'does not log inventory with an incorrect / nil topic' do
       expect(DeviceInventory.count).to eq(0)
-      MqttMessagesHandler.handle_topic('invenxxx','{"random_property":"random_result2"}')
-      MqttMessagesHandler.handle_topic(nil,'{"random_property":"random_result2"}')
+      message_handler.handle_topic('invenxxx','{"random_property":"random_result2"}')
+      message_handler.handle_topic(nil,'{"random_property":"random_result2"}')
       expect(DeviceInventory.count).to eq(0)
     end
 
     it 'does not handshake any device' do
       expect(Redis.current).not_to receive(:publish)
-      MqttMessagesHandler.handle_topic(
+      message_handler.handle_topic(
         @inventory_packet.topic, @inventory_packet.payload
       )
     end
@@ -234,7 +246,7 @@ RSpec.describe MqttMessagesHandler do
   describe '#hardware_info' do
     it 'hardware info has been received and id changed from 47 -> 48' do
       expect(device.hardware_info["id"]).to eq(47)
-      MqttMessagesHandler.handle_topic(@hardware_info_packet.topic, @hardware_info_packet.payload)
+      message_handler.handle_topic(@hardware_info_packet.topic, @hardware_info_packet.payload)
       device.reload
       expect(device.hardware_info["id"]).to eq(48)
       expect(@hardware_info_packet.payload).to eq((device.hardware_info.to_json))
@@ -249,14 +261,14 @@ RSpec.describe MqttMessagesHandler do
           onboarding_session: orphan_device.onboarding_session
         }.to_json
       )
-      MqttMessagesHandler.handle_topic(@hardware_info_packet.topic, @hardware_info_packet.payload)
+      message_handler.handle_topic(@hardware_info_packet.topic, @hardware_info_packet.payload)
       expect(orphan_device.reload.device_handshake).to be true
     end
 
     it 'defers messages with unknown device tokens if retry flag is true' do
       expect(device.hardware_info["id"]).to eq(47)
       expect(RetryMQTTMessageJob).to receive(:perform_later).with(@hardware_info_packet_bad.topic, @hardware_info_packet_bad.payload)
-      MqttMessagesHandler.handle_topic(@hardware_info_packet_bad.topic, @hardware_info_packet_bad.payload)
+      message_handler.handle_topic(@hardware_info_packet_bad.topic, @hardware_info_packet_bad.payload)
       device.reload
       expect(device.hardware_info["id"]).to eq(47)
       expect(@hardware_info_packet_bad.payload).to_not eq((device.hardware_info.to_json))
@@ -265,7 +277,7 @@ RSpec.describe MqttMessagesHandler do
     it 'does not defer messages with unknown device tokens if retry flag is false' do
       expect(device.hardware_info["id"]).to eq(47)
       expect(RetryMQTTMessageJob).not_to receive(:perform_later).with(@hardware_info_packet_bad.topic, @hardware_info_packet_bad.payload)
-      MqttMessagesHandler.handle_topic(@hardware_info_packet_bad.topic, @hardware_info_packet_bad.payload, false)
+      message_handler.handle_topic(@hardware_info_packet_bad.topic, @hardware_info_packet_bad.payload, false)
       device.reload
       expect(device.hardware_info["id"]).to eq(47)
       expect(@hardware_info_packet_bad.payload).to_not eq((device.hardware_info.to_json))

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -522,6 +522,24 @@ RSpec.describe Device, :type => :model do
     end
   end
 
+  describe "forwarding" do
+    describe "#forward_readings?" do
+      it "delegates to the forward_device_readings? method on the device owner" do
+        forward_readings = double(:forward_readings)
+        expect(device.owner).to receive(:forward_device_readings?).and_return(forward_readings)
+        expect(device.forward_readings?).to eq(forward_readings)
+      end
+    end
+
+    describe "#forwarding_token?" do
+      it "delegates to the device owner" do
+        forwarding_token = double(:forwarding_token)
+        expect(device.owner).to receive(:forwarding_token).and_return(forwarding_token)
+        expect(device.forwarding_token).to eq(forwarding_token)
+      end
+    end
+  end
+
   describe "#find_or_create_component_by_sensor_id" do
     context "when the sensor exists and a component already exists for this device" do
       it "returns the existing component" do

--- a/spec/models/storer_spec.rb
+++ b/spec/models/storer_spec.rb
@@ -6,6 +6,16 @@ RSpec.describe Storer, type: :model do
   let(:component){ create(:component, id: 12, device: device, sensor: sensor) }
 
 
+  let(:mqtt_client) {
+    double(:mqtt_client).tap do |mqtt_client|
+      allow(mqtt_client).to receive(:publish)
+    end
+  }
+
+  subject(:storer) {
+    Storer.new(mqtt_client)
+  }
+
   context 'when receiving good data' do
     before do
       allow(Rails.env).to receive(:production?).and_return(true)
@@ -42,7 +52,7 @@ RSpec.describe Storer, type: :model do
       # expect(Kairos).to receive(:http_post_to).with("/datapoints", @karios_data)
       # expect_any_instance_of(Storer).to receive(:ws_publish)
       expect do
-        Storer.new(device, @data)
+        storer.store(device, @data)
       end.not_to raise_error
     end
 
@@ -51,13 +61,15 @@ RSpec.describe Storer, type: :model do
         Time.parse(@data['recorded_at']),
         [sensor.id]
       )
-      Storer.new(device, @data)
+      storer.store(device, @data)
     end
 
     skip 'updates device without touching updated_at' do
       updated_at = device.updated_at
 
-      Storer.new(device, @data)
+      expect(storer).to receive(:ws_publish)
+
+      storer.store(device, @data)
 
       expect(device.reload.updated_at).to eq(updated_at)
 
@@ -65,7 +77,27 @@ RSpec.describe Storer, type: :model do
       expect(device.reload.last_reading_at).not_to eq(nil)
       expect(device.reload.state).to eq('has_published')
 
-      expect(Storer).to receive(:ws_publish)
+    end
+
+    context "when the device allows forwarding" do
+      # TODO tim refactor this now you're injecting the MQTT client
+      it "forwards the message with the forwarding token and the device's id" do
+        forwarding_token = double(:forwarding_token)
+        allow(device).to receive(:forwarding_token).and_return(forwarding_token)
+        allow(device).to receive(:forward_readings?).and_return(true)
+        forwarder = double(:mqtt_forwarder)
+        allow(MQTTForwarder).to receive(:new).and_return(forwarder)
+        expect(forwarder).to receive(:forward_reading).with(forwarding_token, device.id, @data)
+        storer.store(device, @data)
+      end
+    end
+
+    context "when the device does not allow forwarding" do
+      it "does not forward the message" do
+        allow(device).to receive(:forward_readings?).and_return(false)
+        expect_any_instance_of(MQTTForwarder).not_to receive(:forward_reading)
+        storer.store(device, @data)
+      end
     end
   end
 
@@ -81,11 +113,11 @@ RSpec.describe Storer, type: :model do
 
     it 'does raise error' do
       expect(Kairos).not_to receive(:http_post_to).with("/datapoints", anything)
-      expect{ Storer.new(device, @bad_data) }.to raise_error(ArgumentError)
+      expect{ storer.store(device, @bad_data) }.to raise_error(ArgumentError)
     end
 
     it 'does not update device' do
-      expect{ Storer.new(device, @bad_data) }.to raise_error(ArgumentError)
+      expect{ storer.store(device, @bad_data) }.to raise_error(ArgumentError)
 
       expect(device.reload.last_reading_at).to eq(nil)
       expect(device.reload.data).to eq(nil)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -74,24 +74,27 @@ RSpec.describe User, :type => :model do
   describe "forwarding" do
     describe "generating a forwarding token" do
       context "when the user is a citizen" do
-        it "does not generate a forwarding token" do
+        it "does not generate a forwarding token or username" do
           user.role_mask = 0
-          user.regenerate_forwarding_token!
+          user.regenerate_forwarding_tokens!
           expect(user.forwarding_token).to be(nil)
+          expect(user.forwarding_username).to be(nil)
         end
       end
       context "when the user is a researcher" do
-        it "generates a forwarding token" do
+        it "generates a forwarding token and username" do
           user.role_mask = 2
-          user.regenerate_forwarding_token!
+          user.regenerate_forwarding_tokens!
           expect(user.forwarding_token).not_to be(nil)
+          expect(user.forwarding_username).not_to be(nil)
         end
       end
       context "when the user is an admin" do
-        it "generates a forwarding token" do
+        it "generates a forwarding token and username" do
           user.role_mask = 5
-          user.regenerate_forwarding_token!
+          user.regenerate_forwarding_tokens!
           expect(user.forwarding_token).not_to be(nil)
+          expect(user.forwarding_username).not_to be(nil)
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -71,6 +71,49 @@ RSpec.describe User, :type => :model do
     expect(last_email.to).to eq([user.email])
   end
 
+  describe "forwarding" do
+    describe "generating a forwarding token" do
+      context "when the user is a citizen" do
+        it "does not generate a forwarding token" do
+          user.role_mask = 0
+          user.regenerate_forwarding_token!
+          expect(user.forwarding_token).to be(nil)
+        end
+      end
+      context "when the user is a researcher" do
+        it "generates a forwarding token" do
+          user.role_mask = 2
+          user.regenerate_forwarding_token!
+          expect(user.forwarding_token).not_to be(nil)
+        end
+      end
+      context "when the user is an admin" do
+        it "generates a forwarding token" do
+          user.role_mask = 5
+          user.regenerate_forwarding_token!
+          expect(user.forwarding_token).not_to be(nil)
+        end
+      end
+    end
+
+    describe "forwarding device readings" do
+      context "when the user has a forwarding token" do
+        it "forwards device readings" do
+          user.forwarding_token = double(:forwarding_token)
+          expect(user.forward_device_readings?).to be(true)
+        end
+      end
+
+      context "when the user has no forwarding token" do
+        it "does not forward device readings" do
+          user.forwarding_token = nil
+          expect(user.forward_device_readings?).to be(false)
+        end
+      end
+    end
+  end
+
+
   describe "authenticate_with_legacy_support" do
 
     let(:user) { build_stubbed(:user, password: 'password') }

--- a/spec/requests/v0/forwarding_spec.rb
+++ b/spec/requests/v0/forwarding_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+describe V0::ForwardingController, type: :request do
+
+  let(:user) {
+    create(:user, role_mask: 5).tap do |user|
+      user.regenerate_forwarding_tokens!
+      user.save!
+    end
+  }
+
+  let(:token) {
+    user.forwarding_token
+  }
+
+  let(:username) {
+    user.forwarding_username
+  }
+
+  let(:topic) {
+    "/forward/#{token}/device/+/readings"
+  }
+
+  let(:params) {
+    {
+      topic: topic,
+      username: username
+    }
+  }
+
+  shared_examples_for "authorized" do
+    it "authorizes the subscription" do
+      r = api_get "/forward", params
+      expect(response.status).to eq(200)
+      expect(r["result"]).to eq("allow")
+    end
+  end
+
+  shared_examples_for "not authorized" do
+    it "does not authorize the subscription" do
+      r = api_get "/forward", params
+      expect(response.status).to eq(200)
+      expect(r["result"]).to eq("ignore")
+    end
+  end
+
+  context "when the topic is a forwarding topic" do
+    context "when the forwarding token matches a user" do
+      context "when the username matches the user's forwarding_username" do
+        it_behaves_like "authorized"
+      end
+
+      context "when the username does not match the user's forwarding_username" do
+        let(:username) { "other_username" }
+        it_behaves_like "not authorized"
+      end
+    end
+
+    context "when the forwarding token does not match a user" do
+        let(:token) { "other_token" }
+        it_behaves_like "not authorized"
+    end
+  end
+
+  context "when the topic is not a forwarding topic" do
+    let(:topic) { "/some/other/topic" }
+    it_behaves_like "not authorized"
+  end
+
+  context "when no username is supplied" do
+    let(:username) { nil }
+    it_behaves_like "not authorized"
+  end
+
+  context "when no topic is supplied" do
+    let(:topic) { nil }
+    it_behaves_like "not authorized"
+  end
+end

--- a/spec/requests/v0/forwarding_spec.rb
+++ b/spec/requests/v0/forwarding_spec.rb
@@ -40,7 +40,7 @@ describe V0::ForwardingController, type: :request do
     it "does not authorize the subscription" do
       r = api_get "/forward", params
       expect(response.status).to eq(200)
-      expect(r["result"]).to eq("ignore")
+      expect(r["result"]).to eq("deny")
     end
   end
 


### PR DESCRIPTION
WIP on #226.

Includes the creation of forwarding tokens for users and logic to decide whether or not to forward, plus the machinery for doing the forwarding. It's involved a bit more refactoring work than i thought as we need to manage the MQTT client object lifecycle a bit more carefully and pass it around to where its needed. For further discussion and testing on staging on Friday!