### PR TITLE
Bugfix/only retry devices with orphan

### DIFF
--- a/app/controllers/v0/readings_controller.rb
+++ b/app/controllers/v0/readings_controller.rb
@@ -37,7 +37,7 @@ module V0
 
       if request.headers['X-SmartCitizenData']
         MQTTClientFactory.create_client({clean_session: true, client_id: nil}) do |mqtt_client|
-          storer = RawStorer.new(mqtt_client, self)
+          storer = RawStorer.new(mqtt_client)
           JSON.parse(request.headers['X-SmartCitizenData']).each do |raw_reading|
             mac = request.headers['X-SmartCitizenMacADDR']
             version = request.headers['X-SmartCitizenVersion']

--- a/app/jobs/send_to_datastore_job.rb
+++ b/app/jobs/send_to_datastore_job.rb
@@ -16,7 +16,7 @@ class SendToDatastoreJob < ApplicationJob
   end
 
   def storer
-    @storer ||= Storer.new(mqtt_client, ActionController::Base.new.view_context)
+    @storer ||= Storer.new(mqtt_client)
   end
 
   def mqtt_client

--- a/app/lib/mqtt_messages_handler.rb
+++ b/app/lib/mqtt_messages_handler.rb
@@ -53,7 +53,8 @@ class MqttMessagesHandler
   end
 
   def handle_nil_device(topic, message, retry_on_nil_device)
-    if !topic.to_s.include?("inventory") && !topic.to_s.include?("bridge")
+    orphan_device = OrphanDevice.find_by_device_token(device_token(topic))
+    if !topic.to_s.include?("inventory") && !topic.to_s.include?("bridge") && orphan_device
       retry_later(topic, message) if retry_on_nil_device
     end
   end

--- a/app/lib/mqtt_messages_handler.rb
+++ b/app/lib/mqtt_messages_handler.rb
@@ -141,6 +141,6 @@ class MqttMessagesHandler
 
 
   def storer
-    @storer ||= Storer.new(mqtt_client, ActionController::Base.new.view_context)
+    @storer ||= Storer.new(mqtt_client)
   end
 end

--- a/app/models/raw_storer.rb
+++ b/app/models/raw_storer.rb
@@ -5,9 +5,9 @@
 class RawStorer
   include MessageForwarding
 
-  def initialize(mqtt_client, renderer)
+  def initialize(mqtt_client, renderer=nil)
     @mqtt_client = mqtt_client
-    @renderer = renderer
+    @renderer = renderer || ActionController::Base.new.view_context
   end
 
   def store data, mac, version, ip, raise_errors=false

--- a/app/models/storer.rb
+++ b/app/models/storer.rb
@@ -2,9 +2,9 @@ class Storer
   include DataParser::Storer
   include MessageForwarding
 
-  def initialize(mqtt_client, renderer)
+  def initialize(mqtt_client, renderer=nil)
     @mqtt_client = mqtt_client
-    @renderer = renderer
+    @renderer = renderer || ActionController::Base.new.view_context
   end
 
   def store device, reading, do_update = true


### PR DESCRIPTION
Only retry mqtt messages where an orphan device exists for that device token. This will limit queued messages for completely unknown devices.