### PR TITLE
Add new data policy fields

### DIFF
--- a/app/controllers/v0/devices_controller.rb
+++ b/app/controllers/v0/devices_controller.rb
@@ -97,6 +97,7 @@ private
         :device_token,
         :notify_low_battery,
         :notify_stopped_publishing,
+        :precise_location,
         :exposure,
         :meta,
         :user_tags,
@@ -105,7 +106,7 @@ private
 
       # Researchers + Admins can update is_private
       if current_user.role_mask >= 2
-        params_to_permit.push(:is_private, :is_test)
+        params_to_permit.push(:is_private, :is_test, :enable_forwarding)
       end
 
       params.permit(

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -291,7 +291,7 @@ class Device < ActiveRecord::Base
 
   def truncate_and_fuzz_location!
     if latitude && longitude
-      fuzz_decimal_places = 3
+      fuzz_decimal_places = 4
       total_decimal_places = 5
       lat_fuzz = self.precise_location ? 0.0 : (Random.rand * 1/10.0**fuzz_decimal_places)
       long_fuzz = self.precise_location ? 0.0 : (Random.rand * 1/10.0**fuzz_decimal_places)

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -291,11 +291,12 @@ class Device < ActiveRecord::Base
 
   def truncate_and_fuzz_location!
     if latitude && longitude
-      decimal_places = self.precise_location ? 5 : 2
-      lat_fuzz = self.precise_location ? 0.0 : (Random.rand * 1/10.0**decimal_places).truncate(5)
-      long_fuzz = self.precise_location ? 0.0 : (Random.rand * 1/10.0**decimal_places).truncate(5)
-      self.latitude = self.latitude.truncate(decimal_places) + lat_fuzz
-      self.longitude = self.longitude.truncate(decimal_places) + long_fuzz
+      fuzz_decimal_places = 2
+      total_decimal_places = 5
+      lat_fuzz = self.precise_location ? 0.0 : (Random.rand * 1/10.0**fuzz_decimal_places)
+      long_fuzz = self.precise_location ? 0.0 : (Random.rand * 1/10.0**fuzz_decimal_places)
+      self.latitude = (self.latitude + lat_fuzz).truncate(total_decimal_places)
+      self.longitude = (self.longitude + long_fuzz).truncate(total_decimal_places)
     end
   end
 

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -291,7 +291,7 @@ class Device < ActiveRecord::Base
 
   def truncate_and_fuzz_location!
     if latitude && longitude
-      decimal_places = self.precise_location ? 5 : 3
+      decimal_places = self.precise_location ? 5 : 2
       lat_fuzz = self.precise_location ? 0.0 : (Random.rand * 1/10.0**decimal_places).truncate(5)
       long_fuzz = self.precise_location ? 0.0 : (Random.rand * 1/10.0**decimal_places).truncate(5)
       self.latitude = self.latitude.truncate(decimal_places) + lat_fuzz

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -291,7 +291,7 @@ class Device < ActiveRecord::Base
 
   def truncate_and_fuzz_location!
     if latitude && longitude
-      fuzz_decimal_places = 2
+      fuzz_decimal_places = 3
       total_decimal_places = 5
       lat_fuzz = self.precise_location ? 0.0 : (Random.rand * 1/10.0**fuzz_decimal_places)
       long_fuzz = self.precise_location ? 0.0 : (Random.rand * 1/10.0**fuzz_decimal_places)

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -291,7 +291,7 @@ class Device < ActiveRecord::Base
 
   def truncate_and_fuzz_location!
     if latitude && longitude
-      fuzz_decimal_places = 4
+      fuzz_decimal_places = 3
       total_decimal_places = 5
       lat_fuzz = self.precise_location ? 0.0 : (Random.rand * 1/10.0**fuzz_decimal_places)
       long_fuzz = self.precise_location ? 0.0 : (Random.rand * 1/10.0**fuzz_decimal_places)

--- a/app/views/v0/devices/_device.jbuilder
+++ b/app/views/v0/devices/_device.jbuilder
@@ -14,7 +14,6 @@ json.(
   :state,
   :system_tags,
   :user_tags,
-  :is_private,
   :last_reading_at,
   :created_at,
   :updated_at
@@ -35,6 +34,7 @@ else
 end
 json.merge!(postprocessing: device.postprocessing) if local_assigns[:with_postprocessing]
 json.merge!(location: device.formatted_location) if local_assigns[:with_location]
+json.merge!(data_policy: device.data_policy(authorized))
 json.merge!(hardware: device.hardware(authorized))
 
 if local_assigns[:with_owner] && device.owner

--- a/db/migrate/20240624161155_add_data_policy_fields_to_device.rb
+++ b/db/migrate/20240624161155_add_data_policy_fields_to_device.rb
@@ -1,0 +1,8 @@
+class AddDataPolicyFieldsToDevice < ActiveRecord::Migration[6.1]
+  def change
+    add_column :devices, :precise_location, :boolean, null: false, default: false
+    add_column :devices, :enable_forwarding, :boolean, null: false, default: false
+    # Existing devices have precise locations, despite the default for all new ones.
+    execute "UPDATE devices SET precise_location = true"
+  end
+end

--- a/lib/tasks/devices.rake
+++ b/lib/tasks/devices.rake
@@ -1,0 +1,8 @@
+namespace :devices do
+  task :truncate_and_fuzz_locations => :environment do
+    Device.all.each do |device|
+      device.truncate_and_fuzz_location!
+      device.save!(validate: false)
+    end
+  end
+end

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -231,8 +231,8 @@ RSpec.describe Device, :type => :model do
           device.save
           expect(device.latitude).not_to eq(0.12345)
           expect(device.longitude).not_to eq(10.12345)
-          expect((device.latitude - 0.12345).abs.truncate(5)).to be <= 0.001
-          expect((device.longitude - 10.12345).abs.truncate(5)).to be <= 0.001
+          expect((device.latitude - 0.12345).abs.truncate(5)).to be <= 0.0001
+          expect((device.longitude - 10.12345).abs.truncate(5)).to be <= 0.0001
         end
       end
     end

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -231,8 +231,8 @@ RSpec.describe Device, :type => :model do
           device.save
           expect(device.latitude).not_to eq(0.12345)
           expect(device.longitude).not_to eq(10.12345)
-          expect((device.latitude - 0.12345).abs.truncate(5)).to be <= 0.0001
-          expect((device.longitude - 10.12345).abs.truncate(5)).to be <= 0.0001
+          expect((device.latitude - 0.12345).abs.truncate(5)).to be <= 0.001
+          expect((device.longitude - 10.12345).abs.truncate(5)).to be <= 0.001
         end
       end
     end

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe Device, :type => :model do
 
     it "calculates geohash on save" do
       barcelona = create(:device)
-      expect(barcelona.geohash).to match('sp3e9bh31y')
+      expect(barcelona.geohash).to match(/^sp3e/)
     end
 
     skip "calculates elevation on save", :vcr do
@@ -202,6 +202,60 @@ RSpec.describe Device, :type => :model do
     end
 
   end
+
+  describe "location truncation and fuzzing" do
+    context "when the location is changed" do
+      context "when the device has precise location set" do
+        let(:device) {
+          create(:device, precise_location: true)
+
+        }
+
+        it "truncates the location to 5 decimal places" do
+          device.update(latitude: 0.1234567, longitude: 10.1234567)
+          device.save
+          expect(device.latitude).to eq(0.12345)
+          expect(device.longitude).to eq(10.12345)
+        end
+      end
+
+      context "when the device has no precise location set" do
+        let(:device) {
+          create(:device, precise_location: false)
+
+        }
+
+
+        it "truncates the location to 3 decimal places and adds 2 extra dp of randomness" do
+          device.update(latitude: 0.12345, longitude: 10.12345)
+          device.save
+          expect(device.latitude).not_to eq(0.12345)
+          expect(device.longitude).not_to eq(10.12345)
+          expect((device.latitude - 0.12345).abs).to be <= 0.001
+          expect((device.longitude - 10.12345).abs).to be <= 0.001
+        end
+      end
+    end
+
+    context "when the location is not changed" do
+      let(:device) {
+        create(:device, precise_location: false, latitude: 0.12345, longitude: 0.12345)
+
+      }
+
+      it "does not re-fuzz the device location" do
+        lat_before = device.latitude
+        long_before = device.longitude
+
+        device.update(name: "not updating location")
+        device.save!
+
+        expect(device.reload.latitude).to eq(lat_before)
+        expect(device.reload.longitude).to eq(long_before)
+      end
+    end
+  end
+
 
   it "has to_s" do
     device = create(:device, name: 'cool device')
@@ -524,10 +578,51 @@ RSpec.describe Device, :type => :model do
 
   describe "forwarding" do
     describe "#forward_readings?" do
+      context "when the device has forwarding enabled" do
+        let(:device) {
+          create(:device, enable_forwarding: true)
+        }
+
+        context "when forward_device_readings is true on the owning user" do
+          it "forwardds readings" do
+            expect(device.owner).to receive(:forward_device_readings?).and_return(true)
+            expect(device.forward_readings?).to be(true)
+          end
+        end
+
+        context "when forward_device_readings is not true on the owning user" do
+          it "does not forward readings" do
+            expect(device.owner).to receive(:forward_device_readings?).and_return(false)
+            expect(device.forward_readings?).to be(false)
+          end
+        end
+      end
+
+      context "when the device does not have forwarding enabled" do
+        let(:device) {
+          create(:device, enable_forwarding: false)
+        }
+
+        context "when forward_device_readings is true on the owning user" do
+          it "does not forward readings" do
+            allow(device.owner).to receive(:forward_device_readings?).and_return(true)
+            expect(device.forward_readings?).to be(false)
+            expect(device.owner).not_to have_received(:forward_device_readings?)
+          end
+        end
+
+        context "when forward_device_readings is not true on the owning user" do
+          it "does not forward readings" do
+            allow(device.owner).to receive(:forward_device_readings?).and_return(false)
+            expect(device.forward_readings?).to be(false)
+            expect(device.owner).not_to have_received(:forward_device_readings?)
+          end
+        end
+
+
+      end
+
       it "delegates to the forward_device_readings? method on the device owner" do
-        forward_readings = double(:forward_readings)
-        expect(device.owner).to receive(:forward_device_readings?).and_return(forward_readings)
-        expect(device.forward_readings?).to eq(forward_readings)
       end
     end
 

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -231,8 +231,8 @@ RSpec.describe Device, :type => :model do
           device.save
           expect(device.latitude).not_to eq(0.12345)
           expect(device.longitude).not_to eq(10.12345)
-          expect((device.latitude - 0.12345).abs).to be <= 0.001
-          expect((device.longitude - 10.12345).abs).to be <= 0.001
+          expect((device.latitude - 0.12345).abs.truncate(5)).to be <= 0.001
+          expect((device.longitude - 10.12345).abs.truncate(5)).to be <= 0.001
         end
       end
     end

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -226,13 +226,13 @@ RSpec.describe Device, :type => :model do
         }
 
 
-        it "truncates the location to 2 decimal places and adds 3 extra dp of randomness" do
+        it "truncates the location to 3 decimal places and adds 2 extra dp of randomness" do
           device.update(latitude: 0.12345, longitude: 10.12345)
           device.save
           expect(device.latitude).not_to eq(0.12345)
           expect(device.longitude).not_to eq(10.12345)
-          expect((device.latitude - 0.12345).abs.truncate(5)).to be <= 0.01
-          expect((device.longitude - 10.12345).abs.truncate(5)).to be <= 0.01
+          expect((device.latitude - 0.12345).abs.truncate(5)).to be <= 0.001
+          expect((device.longitude - 10.12345).abs.truncate(5)).to be <= 0.001
         end
       end
     end

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -226,13 +226,13 @@ RSpec.describe Device, :type => :model do
         }
 
 
-        it "truncates the location to 3 decimal places and adds 2 extra dp of randomness" do
+        it "truncates the location to 2 decimal places and adds 3 extra dp of randomness" do
           device.update(latitude: 0.12345, longitude: 10.12345)
           device.save
           expect(device.latitude).not_to eq(0.12345)
           expect(device.longitude).not_to eq(10.12345)
-          expect((device.latitude - 0.12345).abs.truncate(5)).to be <= 0.001
-          expect((device.longitude - 10.12345).abs.truncate(5)).to be <= 0.001
+          expect((device.latitude - 0.12345).abs.truncate(5)).to be <= 0.01
+          expect((device.longitude - 10.12345).abs.truncate(5)).to be <= 0.01
         end
       end
     end


### PR DESCRIPTION
- enable_forwarding allows forwarding to be enabled or disabled per device

- precise_location allows users to choose whether precise (5dp) or approxmite (3dp + 2dp of noise) locations are stored.

On deploying we will need to run migrations, then run rake devices:truncate_and_fuzz_locations in order to truncate the existing locations to 5dp.