### PR TITLE
fix device archived_at null bug

### DIFF
--- a/app/jobs/delete_archived_devices_job.rb
+++ b/app/jobs/delete_archived_devices_job.rb
@@ -6,7 +6,8 @@ class DeleteArchivedDevicesJob < ApplicationJob
     CheckupNotifyJob.perform_now("Delete archived devices")
 
     Device.unscoped.where(workflow_state: "archived").each do |device|
-      if device.archived_at < 24.hours.ago
+      p [device.id, device.archived_at]
+      if device.archived_at && device.archived_at < 24.hours.ago
         CheckupNotifyJob.perform_now("deleting archived device #{device.id}")
         device.destroy!
       end

--- a/spec/jobs/delete_archived_devices_job_spec.rb
+++ b/spec/jobs/delete_archived_devices_job_spec.rb
@@ -13,8 +13,12 @@ RSpec.describe DeleteArchivedDevicesJob, type: :job do
     it "should delete all archived devices, archived_at at least 24 hours ago" do
       deviceNormal = create(:device, name: "dontDeleteMe", created_at: 6.weeks.ago, components: [create(:component)])
       deviceArchived = create(:device, name: "deleteMe", created_at: 1.month.ago, components: [create(:component)])
+      deviceArchivedNullArchivedAt = create(:device, name: "dontdeleteMe", created_at: 1.month.ago, components: [create(:component)])
       deviceArchivedToday = create(:device, name: "dontDeleteMe", created_at: 2.months.ago, components: [create(:component)])
       deviceArchived.archive!
+      deviceArchivedNullArchivedAt.archive!
+      deviceArchivedNullArchivedAt.archived_at = nil # A data inconsistency preseent in production that causes the job to fail
+      deviceArchivedNullArchivedAt.save!
       deviceArchivedToday.archive!
       deviceArchived.update!({archived_at: 2.days.ago})
       expect {
@@ -23,6 +27,7 @@ RSpec.describe DeleteArchivedDevicesJob, type: :job do
       expect(Device.unscoped).to include(deviceNormal)
       expect(Device.unscoped).not_to include(deviceArchived)
       expect(Device.unscoped).to include(deviceArchivedToday)
+      expect(Device.unscoped).to include(deviceArchivedNullArchivedAt)
     end
   end
 end


### PR DESCRIPTION
Some devices in production are archived, but don't have an archived_at date. this ensures they don't crash the device archive job.