### PR TITLE
Add models and endpoints for Experiments

### DIFF
--- a/app/controllers/v0/experiments_controller.rb
+++ b/app/controllers/v0/experiments_controller.rb
@@ -1,0 +1,59 @@
+module V0
+  class ExperimentsController < ApplicationController
+
+    before_action :check_if_authorized!, only: [:create, :update, :destroy]
+
+    def index
+      raise_ransack_errors_as_bad_request do
+        @q = Experiment.ransack(params[:q])
+        @q.sorts = 'id asc' if @q.sorts.empty?
+        @experiments = @q.result(distinct: true)
+        @experiments = paginate @experiments
+      end
+    end
+
+    def show
+      @experiment = Experiment.find(params[:id])
+      authorize @experiment
+    end
+
+    def create
+      @experiment = Experiment.new(experiment_params)
+      @experiment.owner ||= current_user
+      authorize @experiment
+      if @experiment.save
+        render :show, status: :created
+      else
+        raise Smartcitizen::UnprocessableEntity.new @experiment.errors
+      end
+    end
+
+    def update
+      @experiment = Experiment.find(params[:id])
+      authorize @experiment
+      if @experiment.update(experiment_params)
+        render :show, status: :ok
+      else
+        raise Smartcitizen::UnprocessableEntity.new @experiment.errors
+      end
+    end
+
+    def destroy
+      @experiment = Experiment.find(params[:id])
+      authorize @experiment
+      if @experiment.destroy!
+        render json: {message: 'OK'}, status: :ok
+      else
+        raise Smartcitizen::UnprocessableEntity.new @experiment.errors
+      end
+    end
+
+    private
+
+    def experiment_params
+      params.permit(
+        :name, :description, :active, :is_test, :starts_at, :ends_at, device_ids: []
+      )
+    end
+  end
+end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -26,6 +26,8 @@ class Device < ActiveRecord::Base
   has_many :sensors, through: :components
   has_one :postprocessing, dependent: :destroy
 
+  has_and_belongs_to_many :experiments
+
   accepts_nested_attributes_for :postprocessing, update_only: true
 
   validates_presence_of :name

--- a/app/models/experiment.rb
+++ b/app/models/experiment.rb
@@ -8,4 +8,9 @@ class Experiment < ApplicationRecord
   def self.ransackable_attributes(auth_object = nil)
     ["created_at", "description", "ends_at", "id", "is_test", "name", "owner_id", "starts_at", "status", "updated_at"]
   end
+
+
+  def active?
+    (!starts_at || Time.now >= starts_at) && (!ends_at || Time.now <= ends_at)
+  end
 end

--- a/app/models/experiment.rb
+++ b/app/models/experiment.rb
@@ -1,11 +1,15 @@
+require_relative "validators/datetime_validator"
+
 class Experiment < ApplicationRecord
   belongs_to :owner, class_name: "User"
   has_and_belongs_to_many :devices
 
   validates_presence_of :name, :owner
   validates_inclusion_of :is_test, in: [true, false]
-
+  validates :starts_at_before_type_cast, datetime: true
+  validates :ends_at_before_type_cast, datetime: true
   validate :cannot_add_private_devices_of_other_users
+  validate :start_date_is_before_end_date
 
   def self.ransackable_attributes(auth_object = nil)
     ["created_at", "description", "ends_at", "id", "is_test", "name", "owner_id", "starts_at", "status", "updated_at"]
@@ -25,4 +29,11 @@ class Experiment < ApplicationRecord
       errors.add(:devices, "can't contain private devices owned by other users (ids: #{ids})")
     end
   end
+
+  def start_date_is_before_end_date
+    if starts_at && ends_at && ends_at < starts_at
+      errors.add(:ends_at, "is before starts_at")
+    end
+  end
+
 end

--- a/app/models/experiment.rb
+++ b/app/models/experiment.rb
@@ -1,0 +1,11 @@
+class Experiment < ApplicationRecord
+  belongs_to :owner, class_name: "User"
+  has_and_belongs_to_many :devices
+
+  validates_presence_of :name, :owner
+  validates_inclusion_of :is_test, in: [true, false]
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["created_at", "description", "ends_at", "id", "is_test", "name", "owner_id", "starts_at", "status", "updated_at"]
+  end
+end

--- a/app/models/experiment.rb
+++ b/app/models/experiment.rb
@@ -15,6 +15,9 @@ class Experiment < ApplicationRecord
     ["created_at", "description", "ends_at", "id", "is_test", "name", "owner_id", "starts_at", "status", "updated_at"]
   end
 
+  def active
+    active?
+  end
 
   def active?
     (!starts_at || Time.now >= starts_at) && (!ends_at || Time.now <= ends_at)

--- a/app/models/validators/datetime_validator.rb
+++ b/app/models/validators/datetime_validator.rb
@@ -1,0 +1,17 @@
+class DatetimeValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    [:starts_at, :ends_at].each do |field|
+      if value.is_a?(String)
+        begin
+          Date.iso8601(value)
+        rescue Date::Error
+          begin
+            Time.iso8601(value)
+          rescue ArgumentError
+            record.errors.add(attribute, "is not a valid ISO8601 date or time")
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/policies/experiment_policy.rb
+++ b/app/policies/experiment_policy.rb
@@ -1,0 +1,13 @@
+class ExperimentPolicy < ApplicationPolicy
+  def update?
+    user.try(:is_admin?) || user == record.owner
+  end
+
+  def create?
+    user
+  end
+
+  def destroy?
+    update?
+  end
+end

--- a/app/views/v0/devices/_device.jbuilder
+++ b/app/views/v0/devices/_device.jbuilder
@@ -55,4 +55,6 @@ end
 
 json.data device.formatted_data if local_assigns[:with_data]
 
+json.experiment_ids device.experiment_ids
+
 

--- a/app/views/v0/experiments/_experiment.jbuilder
+++ b/app/views/v0/experiments/_experiment.jbuilder
@@ -1,0 +1,3 @@
+json.(experiment,
+  :id, :name, :description, :owner_id, :active, :is_test, :starts_at, :ends_at, :device_ids, :created_at, :updated_at
+)

--- a/app/views/v0/experiments/index.jbuilder
+++ b/app/views/v0/experiments/index.jbuilder
@@ -1,0 +1,1 @@
+json.array! @experiments, partial: 'experiment', as: :experiment

--- a/app/views/v0/experiments/show.jbuilder
+++ b/app/views/v0/experiments/show.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "experiment", experiment: @experiment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
     resources :sensors, except: [:destroy]
     resources :components, only: [:show, :index]
     resources :sessions, only: :create
+    resources :experiments
 
     resources :uploads, path: 'avatars' do
       post 'uploaded' => 'uploads#uploaded', on: :collection

--- a/db/migrate/20240718054447_create_experiments.rb
+++ b/db/migrate/20240718054447_create_experiments.rb
@@ -1,0 +1,22 @@
+class CreateExperiments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :experiments do |t|
+      t.string :name, null: false
+      t.string :description
+      t.belongs_to :owner, index: true
+      t.boolean :active, null: false, default: true
+      t.boolean :is_test, null: false, default: false
+      t.datetime :starts_at
+      t.datetime :ends_at
+      t.timestamps
+    end
+    add_foreign_key :experiments, :users, column: :owner_id
+
+    create_table :devices_experiments, id: false do |t|
+      t.belongs_to :device, index: true
+      t.belongs_to :experiment, index: true
+    end
+    add_foreign_key :devices_experiments, :devices, column: :device_id
+    add_foreign_key :devices_experiments, :experiments, column: :experiment_id
+  end
+end

--- a/db/migrate/20240812081108_remove_active_flag_from_experiments.rb
+++ b/db/migrate/20240812081108_remove_active_flag_from_experiments.rb
@@ -1,0 +1,5 @@
+class RemoveActiveFlagFromExperiments < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :experiments, :active, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_18_054447) do
+ActiveRecord::Schema.define(version: 2024_08_12_081108) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "adminpack"
@@ -140,7 +140,6 @@ ActiveRecord::Schema.define(version: 2024_07_18_054447) do
     t.string "name", null: false
     t.string "description"
     t.bigint "owner_id"
-    t.boolean "active", default: true, null: false
     t.boolean "is_test", default: false, null: false
     t.datetime "starts_at"
     t.datetime "ends_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_06_24_175242) do
+ActiveRecord::Schema.define(version: 2024_07_18_054447) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "adminpack"
@@ -116,6 +116,13 @@ ActiveRecord::Schema.define(version: 2024_06_24_175242) do
     t.index ["workflow_state"], name: "index_devices_on_workflow_state"
   end
 
+  create_table "devices_experiments", id: false, force: :cascade do |t|
+    t.bigint "device_id"
+    t.bigint "experiment_id"
+    t.index ["device_id"], name: "index_devices_experiments_on_device_id"
+    t.index ["experiment_id"], name: "index_devices_experiments_on_experiment_id"
+  end
+
   create_table "devices_inventory", id: :serial, force: :cascade do |t|
     t.jsonb "report", default: {}
     t.datetime "created_at"
@@ -127,6 +134,19 @@ ActiveRecord::Schema.define(version: 2024_06_24_175242) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["device_id", "tag_id"], name: "index_devices_tags_on_device_id_and_tag_id", unique: true
+  end
+
+  create_table "experiments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "description"
+    t.bigint "owner_id"
+    t.boolean "active", default: true, null: false
+    t.boolean "is_test", default: false, null: false
+    t.datetime "starts_at"
+    t.datetime "ends_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["owner_id"], name: "index_experiments_on_owner_id"
   end
 
   create_table "friendly_id_slugs", id: :serial, force: :cascade do |t|
@@ -313,8 +333,11 @@ ActiveRecord::Schema.define(version: 2024_06_24_175242) do
   add_foreign_key "api_tokens", "users", column: "owner_id"
   add_foreign_key "components", "devices"
   add_foreign_key "components", "sensors"
+  add_foreign_key "devices_experiments", "devices"
+  add_foreign_key "devices_experiments", "experiments"
   add_foreign_key "devices_tags", "devices"
   add_foreign_key "devices_tags", "tags"
+  add_foreign_key "experiments", "users", column: "owner_id"
   add_foreign_key "postprocessings", "devices"
   add_foreign_key "sensors", "measurements"
   add_foreign_key "uploads", "users"

--- a/spec/factories/experiment.rb
+++ b/spec/factories/experiment.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
     sequence("name") { |n| "experiment#{n}"}
     description { "my experiment" }
     association :owner, factory: :user
-    active { true }
     is_test { false }
   end
 end

--- a/spec/factories/experiment.rb
+++ b/spec/factories/experiment.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :experiment do
+    sequence("name") { |n| "experiment#{n}"}
+    description { "my experiment" }
+    association :owner, factory: :user
+    active { true }
+    is_test { false }
+  end
+end

--- a/spec/models/experiment_spec.rb
+++ b/spec/models/experiment_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe Experiment, type: :model do
+
+  describe "#is_active?" do
+    context "when the experiment has neither start or end times" do
+      it "is active" do
+        experiment = build(:experiment, starts_at: nil, ends_at: nil)
+        expect(experiment).to be_active
+      end
+    end
+
+    context "when the experiment has a start time but no end time" do
+      it "is inactive before the start time" do
+        experiment = build(:experiment, starts_at: Time.now + 1.hour, ends_at: nil)
+        expect(experiment).not_to be_active
+      end
+
+      it "is active after the start time" do
+        experiment = build(:experiment, starts_at: Time.now - 1.hour, ends_at: nil)
+        expect(experiment).to be_active
+      end
+    end
+
+    context "when the experiment has an end time but no start time" do
+      it "is active before the end time" do
+        experiment = build(:experiment, starts_at: nil, ends_at: Time.now + 1.hour)
+        expect(experiment).to be_active
+      end
+
+      it "is inactive after the end time" do
+        experiment = build(:experiment, starts_at: nil, ends_at: Time.now - 1.hour)
+        expect(experiment).not_to be_active
+      end
+    end
+
+    context "when the experiment has both start and end times" do
+      it "is inactive before the start time" do
+        experiment = build(:experiment, starts_at: Time.now + 1.hour, ends_at: Time.now + 2.hours)
+        expect(experiment).not_to be_active
+      end
+
+      it "is active between the start and end times" do
+        experiment = build(:experiment, starts_at: Time.now - 1.hour, ends_at: Time.now + 1.hour)
+        expect(experiment).to be_active
+      end
+
+      it "is inactive after the end time" do
+        experiment = build(:experiment, starts_at: Time.now - 2.hours, ends_at: Time.now - 1.hour)
+        expect(experiment).not_to be_active
+      end
+    end
+  end
+end

--- a/spec/models/experiment_spec.rb
+++ b/spec/models/experiment_spec.rb
@@ -1,35 +1,94 @@
 require "rails_helper"
 
 RSpec.describe Experiment, type: :model do
-
-
   describe "validations" do
-    context "when the experiment has private devices owned by the same owner" do
-      it "is valid" do
-        owner = create(:user)
-        device = create(:device, is_private: true, owner: owner)
-        experiment = build(:experiment, owner: owner, devices: [device])
-        expect(experiment).to be_valid
+    describe "validate date format" do
+      describe "start date" do
+        it "is valid with a full iso datetime string" do
+          experiment = build(:experiment, starts_at: "2024-01-02T06:00:00Z")
+          expect(experiment).to be_valid
+        end
+
+        it "is valid with a date only iso datetime string" do
+          experiment = build(:experiment, starts_at: "2024-01-02")
+          expect(experiment).to be_valid
+        end
+
+        it "is invalid with an invalid datetime" do
+          experiment = build(:experiment, starts_at: "lolwut")
+          expect(experiment).not_to be_valid
+        end
+      end
+
+      describe "end date" do
+        it "is valid with a full iso datetime string" do
+          experiment = build(:experiment, ends_at: "2024-01-02T06:00:00Z")
+          expect(experiment).to be_valid
+        end
+
+        it "is valid with a date only iso datetime string" do
+          experiment = build(:experiment, ends_at: "2024-01-02")
+          expect(experiment).to be_valid
+        end
+
+        it "is invalid with an invalid datetime" do
+          experiment = build(:experiment, ends_at: "lolwut")
+          expect(experiment).not_to be_valid
+        end
       end
     end
 
-    context "when the experiment has public devices owned by another user" do
-      it "is valid" do
-        device_owner = create(:user)
-        experiment_owner = create(:user)
-        device = create(:device, is_private: false, owner: device_owner)
-        experiment = build(:experiment, owner: experiment_owner, devices: [device])
-        expect(experiment).to be_valid
-      end
-    end
-
-    context "when the experiment has private devices owned by another user" do
-      it "is not valid" do
-        device_owner = create(:user)
-        experiment_owner = create(:user)
-        device = create(:device, is_private: true, owner: device_owner)
-        experiment = build(:experiment, owner: experiment_owner, devices: [device])
+    describe "start date is before end date" do
+      it "is invalid when end date is before start date" do
+        experiment = build(:experiment, starts_at: "2024-02-01", ends_at: "2024-01-01")
         expect(experiment).not_to be_valid
+      end
+
+      it "is valid when start date is before end date" do
+        experiment = build(:experiment, starts_at: "2024-01-01", ends_at: "2024-02-01")
+        expect(experiment).to be_valid
+      end
+
+      it "is valid with only a start date" do
+        experiment = build(:experiment, starts_at: "2024-01-01")
+        expect(experiment).to be_valid
+      end
+
+      it "is valid with only an end date" do
+        experiment = build(:experiment, ends_at: "2024-01-01")
+        expect(experiment).to be_valid
+      end
+    end
+
+
+    describe "device privacy" do
+      context "when the experiment has private devices owned by the same owner" do
+        it "is valid" do
+          owner = create(:user)
+          device = create(:device, is_private: true, owner: owner)
+          experiment = build(:experiment, owner: owner, devices: [device])
+          expect(experiment).to be_valid
+        end
+      end
+
+      context "when the experiment has public devices owned by another user" do
+        it "is valid" do
+          device_owner = create(:user)
+          experiment_owner = create(:user)
+          device = create(:device, is_private: false, owner: device_owner)
+          experiment = build(:experiment, owner: experiment_owner, devices: [device])
+          expect(experiment).to be_valid
+        end
+      end
+
+      context "when the experiment has private devices owned by another user" do
+        it "is not valid" do
+          device_owner = create(:user)
+          experiment_owner = create(:user)
+          device = create(:device, is_private: true, owner: device_owner)
+          experiment = build(:experiment, owner: experiment_owner, devices: [device])
+          expect(experiment).not_to be_valid
+        end
       end
     end
   end

--- a/spec/models/experiment_spec.rb
+++ b/spec/models/experiment_spec.rb
@@ -2,6 +2,38 @@ require "rails_helper"
 
 RSpec.describe Experiment, type: :model do
 
+
+  describe "validations" do
+    context "when the experiment has private devices owned by the same owner" do
+      it "is valid" do
+        owner = create(:user)
+        device = create(:device, is_private: true, owner: owner)
+        experiment = build(:experiment, owner: owner, devices: [device])
+        expect(experiment).to be_valid
+      end
+    end
+
+    context "when the experiment has public devices owned by another user" do
+      it "is valid" do
+        device_owner = create(:user)
+        experiment_owner = create(:user)
+        device = create(:device, is_private: false, owner: device_owner)
+        experiment = build(:experiment, owner: experiment_owner, devices: [device])
+        expect(experiment).to be_valid
+      end
+    end
+
+    context "when the experiment has private devices owned by another user" do
+      it "is not valid" do
+        device_owner = create(:user)
+        experiment_owner = create(:user)
+        device = create(:device, is_private: true, owner: device_owner)
+        experiment = build(:experiment, owner: experiment_owner, devices: [device])
+        expect(experiment).not_to be_valid
+      end
+    end
+  end
+
   describe "#is_active?" do
     context "when the experiment has neither start or end times" do
       it "is active" do

--- a/spec/requests/v0/devices_spec.rb
+++ b/spec/requests/v0/devices_spec.rb
@@ -24,7 +24,7 @@ describe V0::DevicesController do
       expect(json.length).to eq(2)
       # expect(json[0]['name']).to eq(first.name)
       # expect(json[1]['name']).to eq(second.name)
-      expect(json[0].keys).to eq(%w(id uuid name description state system_tags user_tags last_reading_at created_at updated_at notify device_token postprocessing location data_policy hardware owner data))
+      expect(json[0].keys).to eq(%w(id uuid name description state system_tags user_tags last_reading_at created_at updated_at notify device_token postprocessing location data_policy hardware owner data experiment_ids))
     end
 
     describe "when not logged in" do

--- a/spec/requests/v0/experiments_spec.rb
+++ b/spec/requests/v0/experiments_spec.rb
@@ -1,0 +1,179 @@
+require 'rails_helper'
+
+describe V0::ExperimentsController do
+
+  let(:application) { create :application }
+
+  let(:citizen_user) { create :user }
+  let(:citizen_token) { create :access_token, application: application, resource_owner_id: citizen_user.id }
+
+  let(:admin_user) { create :admin }
+  let(:admin_token) { create :access_token, application: application, resource_owner_id: admin_user.id }
+
+  let(:owner_user) { create :user }
+  let(:owner_token) { create :access_token, application: application, resource_owner_id: owner_user.id }
+
+  let(:experiment) {
+    create(:experiment, name: "Existing experiment", owner: owner_user)
+  }
+
+  let(:device) { create(:device) }
+  let(:valid_params) {
+    {
+      name: "test experiment",
+      description: "a test experiment",
+      is_test: false,
+      active: true,
+      starts_at: "2024-01-01T00:00:00Z",
+      ends_at: "2024-06-30T23:59:59Z",
+      device_ids: [ device.id ]
+    }
+  }
+
+  describe "GET /experiments" do
+    it "lists all experiments" do
+      first = create(:experiment, name: "first experiment")
+      second = create(:experiment, name: "second experiment")
+      j = api_get 'experiments'
+
+      expect(j.length).to eq(2)
+      expect(j[0]['name']).to eq('first experiment')
+      expect(j[1]['name']).to eq('second experiment')
+      expect(response.status).to eq(200)
+    end
+  end
+
+  describe "POST /experiments" do
+    context "When no user is logged in" do
+      it "does not create an experiment" do
+        before_count = Experiment.count
+        api_post "experiments", valid_params
+
+        expect(response.status).to eq(401)
+        expect(Experiment.count).to eq(before_count)
+      end
+    end
+
+    context "When a user is logged in" do
+      it "creates an experiment" do
+        before_count = Experiment.count
+        api_post "experiments", valid_params.merge(access_token: citizen_token.token)
+
+        expect(response.status).to eq(201)
+        expect(Experiment.count).to eq(before_count + 1)
+        created = Experiment.last
+        expect(created.name).to eq(valid_params[:name])
+        expect(created.description).to eq(valid_params[:description])
+        expect(created.is_test).to eq(valid_params[:is_test])
+        expect(created.active).to eq(valid_params[:active])
+        expect(created.starts_at).to eq(Time.parse(valid_params[:starts_at]))
+        expect(created.ends_at).to eq(Time.parse(valid_params[:ends_at]))
+        expect(created.device_ids).to eq(valid_params[:device_ids])
+      end
+    end
+  end
+
+  describe "GET /experiments/:id" do
+
+    it "returns the experiment" do
+      json = api_get "experiments/#{experiment.id}"
+
+      expect(response.status).to eq(200)
+      expect(json["name"]).to eq experiment.name
+    end
+  end
+
+  describe "PUT /experiments/:id" do
+    context "When no user is logged in" do
+      it "does not update the experiment" do
+        json = api_put "experiments/#{experiment.id}", valid_params
+
+        updated = Experiment.find(experiment.id)
+        expect(response.status).to eq(401)
+        expect(updated).to eq(experiment)
+      end
+    end
+
+    context "When the experiment owner is logged in" do
+      it "updates the experiment" do
+        json = api_put "experiments/#{experiment.id}", valid_params.merge(access_token: owner_token.token)
+
+        updated = Experiment.find(experiment.id)
+        expect(updated.name).to eq(valid_params[:name])
+        expect(updated.description).to eq(valid_params[:description])
+        expect(updated.is_test).to eq(valid_params[:is_test])
+        expect(updated.active).to eq(valid_params[:active])
+        expect(updated.starts_at).to eq(Time.parse(valid_params[:starts_at]))
+        expect(updated.ends_at).to eq(Time.parse(valid_params[:ends_at]))
+        expect(updated.device_ids).to eq(valid_params[:device_ids])
+      end
+    end
+
+    context "When a different user is logged in" do
+      it "does not update the experiment" do
+        json = api_put "experiments/#{experiment.id}", valid_params.merge(access_token: citizen_token.token)
+
+        expect(response.status).to eq(403)
+        updated = Experiment.find(experiment.id)
+        expect(updated).to eq(experiment)
+      end
+    end
+
+    context "When an admin is logged in" do
+      it "updates the experiment" do
+        json = api_put "experiments/#{experiment.id}", valid_params.merge(access_token: admin_token.token)
+
+        updated = Experiment.find(experiment.id)
+        expect(updated.name).to eq(valid_params[:name])
+        expect(updated.description).to eq(valid_params[:description])
+        expect(updated.is_test).to eq(valid_params[:is_test])
+        expect(updated.active).to eq(valid_params[:active])
+        expect(updated.starts_at).to eq(Time.parse(valid_params[:starts_at]))
+        expect(updated.ends_at).to eq(Time.parse(valid_params[:ends_at]))
+        expect(updated.device_ids).to eq(valid_params[:device_ids])
+      end
+    end
+  end
+
+  describe "DELETE /experiments/:id" do
+    context "When no user is logged in" do
+      it "does not delete the experiment" do
+        json = api_delete "experiments/#{experiment.id}"
+
+        updated = Experiment.where(id: experiment.id).first
+        expect(response.status).to eq(401)
+        expect(updated).not_to be(nil)
+      end
+    end
+
+    context "When the experiment owner is logged in" do
+      it "deletes the experiment" do
+        json = api_delete "experiments/#{experiment.id}", access_token: owner_token.token
+
+        updated = Experiment.where(id: experiment.id).first
+        expect(response.status).to eq(200)
+        expect(updated).to be(nil)
+      end
+    end
+
+    context "When a different user is logged in" do
+      it "does not delete the experiment" do
+        json = api_delete "experiments/#{experiment.id}", access_token: citizen_token.token
+
+        updated = Experiment.where(id: experiment.id).first
+        expect(response.status).to eq(403)
+        expect(updated).not_to be(nil)
+      end
+    end
+
+    context "When an admin is logged in" do
+      it "deletes the experiment" do
+        json = api_delete "experiments/#{experiment.id}", access_token: admin_token.token
+
+        updated = Experiment.where(id: experiment.id).first
+        expect(response.status).to eq(200)
+        expect(updated).to be(nil)
+      end
+    end
+  end
+end

--- a/spec/requests/v0/experiments_spec.rb
+++ b/spec/requests/v0/experiments_spec.rb
@@ -23,7 +23,6 @@ describe V0::ExperimentsController do
       name: "test experiment",
       description: "a test experiment",
       is_test: false,
-      active: true,
       starts_at: "2024-01-01T00:00:00Z",
       ends_at: "2024-06-30T23:59:59Z",
       device_ids: [ device.id ]
@@ -65,7 +64,6 @@ describe V0::ExperimentsController do
         expect(created.name).to eq(valid_params[:name])
         expect(created.description).to eq(valid_params[:description])
         expect(created.is_test).to eq(valid_params[:is_test])
-        expect(created.active).to eq(valid_params[:active])
         expect(created.starts_at).to eq(Time.parse(valid_params[:starts_at]))
         expect(created.ends_at).to eq(Time.parse(valid_params[:ends_at]))
         expect(created.device_ids).to eq(valid_params[:device_ids])
@@ -102,7 +100,6 @@ describe V0::ExperimentsController do
         expect(updated.name).to eq(valid_params[:name])
         expect(updated.description).to eq(valid_params[:description])
         expect(updated.is_test).to eq(valid_params[:is_test])
-        expect(updated.active).to eq(valid_params[:active])
         expect(updated.starts_at).to eq(Time.parse(valid_params[:starts_at]))
         expect(updated.ends_at).to eq(Time.parse(valid_params[:ends_at]))
         expect(updated.device_ids).to eq(valid_params[:device_ids])
@@ -127,7 +124,6 @@ describe V0::ExperimentsController do
         expect(updated.name).to eq(valid_params[:name])
         expect(updated.description).to eq(valid_params[:description])
         expect(updated.is_test).to eq(valid_params[:is_test])
-        expect(updated.active).to eq(valid_params[:active])
         expect(updated.starts_at).to eq(Time.parse(valid_params[:starts_at]))
         expect(updated.ends_at).to eq(Time.parse(valid_params[:ends_at]))
         expect(updated.device_ids).to eq(valid_params[:device_ids])


### PR DESCRIPTION
Experiments are groups of devices which are being used as part of a single experiment.

An experiment has an optional start and end time, and is owned by a user - the user does not need to own the participating devices.

you get GET/PUT/PATCH/POST/DELETE to the /v0/experiments endpoint with json like:

```json
    {
      "name": "test experiment",
      "description": "a test experiment",
      "is_test": false,
      "active": true,
      "starts_at": "2024-01-01T00:00:00Z",
      "ends_at": "2024-06-30T23:59:59Z",
      "device_ids": [ 123, 456, 789 ]
    }

```