### PR TITLE
generate and expose forwarding tokens and usernames

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,7 @@ class User < ActiveRecord::Base
   has_one_attached :profile_picture
 
   before_create :generate_legacy_api_key
+  before_save :generate_forwarding_tokens
 
 
   def self.forwarding_subscription_authorized?(token, username)
@@ -170,6 +171,12 @@ private
 
   def generate_legacy_api_key
     generate_token(:legacy_api_key, Digest::SHA1.hexdigest(SecureRandom.uuid) )
+  end
+
+  def generate_forwarding_tokens
+    if is_admin_or_researcher? && forwarding_token.blank?
+      regenerate_forwarding_tokens!
+    end
   end
 
   def generate_token(column, token=SecureRandom.urlsafe_base64)

--- a/app/views/v0/users/_user.jbuilder
+++ b/app/views/v0/users/_user.jbuilder
@@ -17,9 +17,13 @@ authorized = current_user && current_user == user || current_user&.is_admin?
 if authorized
   json.merge! email: user.email
   json.merge! legacy_api_key: user.legacy_api_key
+  json.merge! forwarding_token: user.forwarding_token
+  json.merge! forwarding_username: user.forwarding_username
 else
   json.merge! email: '[FILTERED]'
   json.merge! legacy_api_key: '[FILTERED]'
+  json.merge! forwarding_token: '[FILTERED]'
+  json.merge! forwarding_username: '[FILTERED]'
 end
 
 json.devices user.devices.filter { |d|

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -52,4 +52,12 @@ namespace :users do
         puts "Check moved devices: #{Device.count} (should be #{count_devices}, #{count_moved_devices} moved)"
         puts "Check deleted users: #{User.count} (should be #{count_users - count_deleted_users}, #{count_deleted_users} deleted)"
     end
+
+    task :generate_forwarding_tokens => :environment do
+      User.where("role_mask >= 4 AND forwarding_token IS NULL").each do |user|
+        puts "Generating tokens for user #{user.username} (role_mask: #{user.role_mask}, id: #{user.id})"
+        user.regenerate_forwarding_tokens!
+        user.save!
+      end
+    end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -171,6 +171,70 @@ RSpec.describe User, :type => :model do
     end
   end
 
+  describe "generating forwarding tokens" do
+    context "on creating a new admin user" do
+      it "generates forwarding tokens" do
+        user = build(:user, role_mask: 7)
+        user.save!
+        expect(user.forwarding_token).not_to be(nil)
+        expect(user.forwarding_username).not_to be(nil)
+      end
+    end
+
+    context "on creating a new researcher user" do
+      it "generates forwarding tokens" do
+        user = build(:user, role_mask: 4)
+        user.save!
+        expect(user.forwarding_token).not_to be(nil)
+        expect(user.forwarding_username).not_to be(nil)
+      end
+    end
+
+    context "on creating a new citizen user" do
+      it "does not generate forwarding tokens" do
+        user = build(:user, role_mask: 0)
+        user.save!
+        expect(user.forwarding_token).to be(nil)
+        expect(user.forwarding_username).to be(nil)
+      end
+    end
+
+    context "on upgrading a user" do
+      context "when the user already has forwarding tokens" do
+        it "does not generate new tokens" do
+          user = build(:user, role_mask: 4)
+          user.save!
+          existing_token = user.forwarding_token
+          existing_username = user.forwarding_username
+          user.reload
+
+          user.role_mask = 7
+          user.save!
+
+          expect(user.forwarding_token).not_to be(nil)
+          expect(user.forwarding_username).not_to be(nil)
+
+          expect(user.forwarding_token).to eq(existing_token)
+          expect(user.forwarding_username).to eq(existing_username)
+        end
+      end
+
+      context "when the user does not have forwarding tokens" do
+        it "generates new tokens" do
+          user = build(:user, role_mask: 0)
+          user.save!
+
+          user.role_mask = 7
+          user.save!
+
+          expect(user.forwarding_token).not_to be(nil)
+          expect(user.forwarding_username).not_to be(nil)
+        end
+      end
+    end
+  end
+
+
   describe "states" do
     it "has a default active state" do
       expect(user.workflow_state).to eq('active')

--- a/spec/requests/v0/users_spec.rb
+++ b/spec/requests/v0/users_spec.rb
@@ -42,6 +42,22 @@ describe V0::UsersController do
       expect(j['email']).to eq(user.email)
     end
 
+    it "des not include the forwarding token and username by default" do
+      user.role_mask = 4
+      user.save!
+      j = api_get "users/testguy"
+      expect(j["forwarding_token"]).to eq("[FILTERED]")
+      expect(j["forwarding_username"]).to eq("[FILTERED]")
+    end
+
+    it "includes the forwarding token and username for the owner" do
+      user.role_mask = 4
+      user.save!
+      j = api_get "users/testguy?access_token=#{token.token}"
+      expect(j["forwarding_token"]).to eq(user.forwarding_token)
+      expect(j["forwarding_username"]).to eq(user.forwarding_username)
+    end
+
     describe "device privacy" do
       before do
         @private_device = create(:device, owner: user, is_private: true)


### PR DESCRIPTION
Forwarding tokens are now available to logged in users for their own account, and to admins for everyone, on the /users endpoint.

Tokens are generated automatically for researchers and admins  on creation or privilege escalation

A new rake task `users:generate_forwarding_tokens` in order to backfill tokens for existing users without them