### PR TITLE
ignore cassandra data in docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ capybara-*.html
 /log/*.log*
 coverage
 tmp/cache
+sck-cassandra


### PR DESCRIPTION
This speeds up build time on staging, where we run cassandra locally, and stops the built images getting unnecessarily enormous