### PR TITLE
admin users can update user role mask

### DIFF
--- a/app/controllers/v0/users_controller.rb
+++ b/app/controllers/v0/users_controller.rb
@@ -55,14 +55,15 @@ module V0
 private
 
     def user_params
-      params.permit(
+      params.permit(*[
         :email,
         :username,
         :password,
         :city,
         :country_code,
         :url,
-      )
+        (:role_mask if current_user&.is_admin?)
+      ].compact)
     end
 
   end


### PR DESCRIPTION
Allow admins to promote or demote user roles by passing a role_mask when updating:

eg `curl 'https://staging-api.smartcitizen.me/v0/users/USERNAME' -X PATCH -H 'Content-Type: application/json;charset=UTF-8' -H 'Authorization: Bearer API_TOKEN' --data-binary '{"role_mask": 2}' --compressed`