### PR TITLE
healthchecks to restart web container when app restarted

### DIFF
--- a/compose/app.yml
+++ b/compose/app.yml
@@ -25,6 +25,9 @@ services:
           memory: 2gb
     volumes:
       - "../:/app"
+    healthcheck:
+      test: ["CMD-SHELL", "curl http://localhost:3000"]
+      timeout: 10s
     #command: rails server -p 3000 -b '0.0.0.0'
     #command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     environment:

--- a/compose/web.yml
+++ b/compose/web.yml
@@ -2,7 +2,9 @@ services:
   web:
     image: nginx
     depends_on:
-      - app
+      app:
+        condition: service_healthy
+        restart: true
     ports:
       - 80:80
       - 80:80/udp


### PR DESCRIPTION
Ensures there's no downtime when the oom_killer runs