### PR TITLE
MQTT subscription

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,6 @@ gem 'workflow-activerecord'
 gem 'em-mqtt'
 
 group :test do
-  gem "database_cleaner-active_record"
   gem 'simplecov', require: false
   gem 'timecop'
   gem 'vcr'

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ gem 'workflow-activerecord'
 gem 'em-mqtt'
 
 group :test do
+  gem "database_cleaner-active_record"
   gem 'simplecov', require: false
   gem 'timecop'
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,10 @@ GEM
     css_parser (1.14.0)
       addressable
     dalli (3.2.4)
+    database_cleaner-active_record (2.2.0)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     date (3.3.3)
     date_validator (0.12.0)
       activemodel (>= 3)
@@ -548,6 +552,7 @@ DEPENDENCIES
   cane
   countries
   dalli
+  database_cleaner-active_record
   date_validator
   diffy
   doorkeeper (~> 5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,10 +131,6 @@ GEM
     css_parser (1.14.0)
       addressable
     dalli (3.2.4)
-    database_cleaner-active_record (2.2.0)
-      activerecord (>= 5.a)
-      database_cleaner-core (~> 2.0.0)
-    database_cleaner-core (2.0.1)
     date (3.3.3)
     date_validator (0.12.0)
       activemodel (>= 3)
@@ -552,7 +548,6 @@ DEPENDENCIES
   cane
   countries
   dalli
-  database_cleaner-active_record
   date_validator
   diffy
   doorkeeper (~> 5)
@@ -625,4 +620,4 @@ RUBY VERSION
    ruby 3.0.6p216
 
 BUNDLED WITH
-   2.5.20
+   2.5.21

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -5,8 +5,17 @@ class Component < ActiveRecord::Base
   belongs_to :sensor
 
   validates_presence_of :device, :sensor
-  validates :sensor_id, :uniqueness => { :scope => [:device_id] }
-  validates :key, :uniqueness => { :scope =>  [:device_id] }
+
+  # IMPORTANT: Validation of sensor/device uniqueness is done at the database level,
+  # as this allows us to use the create_or_find_by! method to atomically upsert components
+  # in the mqtt-task, avoiding component duplication due to race conditions.
+  # For some reason, create_or_find_by! ONLY works when the database constraint is
+  # the ONLY uniqueness constraint on those two values, so adding a rails validation here
+  # causes an error. Leaving the validations here commented out by way of documentation.
+  # See https://stackoverflow.com/questions/74566974/create-or-find-by-not-working-as-it-should-in-rails-6
+  # validates :sensor_id, :uniqueness => { :scope => [:device_id] }
+  # validates :key, :uniqueness => { :scope =>  [:device_id] }
+
 
   before_validation :set_key, on: :create
 

--- a/app/models/concerns/data_parser/storer.rb
+++ b/app/models/concerns/data_parser/storer.rb
@@ -54,7 +54,7 @@ module DataParser
       end
 
       def sensor_reading(device, sensor)
-        component = device.find_or_create_component_for_sensor_reading(sensor)
+        component = device.create_or_find_component_for_sensor_reading(sensor)
         return nil if component.nil?
         value = component.normalized_value( (Float(sensor['value']) rescue sensor['value']) )
         {

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -251,8 +251,8 @@ class Device < ActiveRecord::Base
 
   def update_component_timestamps(timestamp, sensor_ids)
     components.select {|c| sensor_ids.include?(c.sensor_id) }.each do |component|
-      component.transaction do
-        component.lock!
+      component.lock! if self.class.connection.transaction_open?
+      if !component.reload.last_reading_at || timestamp > component.last_reading_at
         component.update_column(:last_reading_at, timestamp)
       end
     end

--- a/app/models/raw_storer.rb
+++ b/app/models/raw_storer.rb
@@ -30,7 +30,7 @@ class RawStorer
 
         metric_id = device.find_sensor_id_by_key(metric)
 
-        component = device.find_or_create_component_by_sensor_id(metric_id)
+        component = device.create_or_find_component_by_sensor_id(metric_id)
         next if component.nil?
 
         value = component.normalized_value( (Float(value) rescue value) )

--- a/app/models/storer.rb
+++ b/app/models/storer.rb
@@ -23,7 +23,7 @@ class Storer
 
   def update_device(device, parsed_ts, sql_data)
     return if parsed_ts <= Time.at(0)
-    device.transaction(isolation: :serializable) do
+    device.transaction do
       device.lock!
       if device.reload.last_reading_at.present?
         # Comparison errors if device.last_reading_at is nil (new devices).

--- a/app/models/storer.rb
+++ b/app/models/storer.rb
@@ -23,18 +23,20 @@ class Storer
 
   def update_device(device, parsed_ts, sql_data)
     return if parsed_ts <= Time.at(0)
+    device.transaction(isolation: :serializable) do
+      device.lock!
+      if device.reload.last_reading_at.present?
+        # Comparison errors if device.last_reading_at is nil (new devices).
+        # Devices can post multiple readings, in a non-sorted order.
+        # Do not update data with an older timestamp.
+        return if parsed_ts < device.last_reading_at
+      end
 
-    if device.last_reading_at.present?
-      # Comparison errors if device.last_reading_at is nil (new devices).
-      # Devices can post multiple readings, in a non-sorted order.
-      # Do not update data with an older timestamp.
-      return if parsed_ts < device.last_reading_at
+      sql_data = device.data.present? ? device.data.merge(sql_data) : sql_data
+      device.update_columns(last_reading_at: parsed_ts, data: sql_data, state: 'has_published')
+      sensor_ids = sql_data.select { |k, v| k.is_a?(Integer) }.keys.compact.uniq
+      device.update_component_timestamps(parsed_ts, sensor_ids)
     end
-
-    sql_data = device.data.present? ? device.data.merge(sql_data) : sql_data
-    device.update_columns(last_reading_at: parsed_ts, data: sql_data, state: 'has_published')
-    sensor_ids = sql_data.select { |k, v| k.is_a?(Integer) }.keys.compact.uniq
-    device.update_component_timestamps(parsed_ts, sensor_ids)
   end
 
   def kairos_publish(reading_data)

--- a/compose.override.local.yml
+++ b/compose.override.local.yml
@@ -7,7 +7,11 @@ services:
     restart: "no"
   sidekiq:
     restart: "no"
-  mqtt-task:
+  mqtt-task-main-1:
+    restart: "no"
+  mqtt-task-main-2:
+    restart: "no"
+  mqtt-task-secondary:
     restart: "no"
   telnet-task:
     restart: "no"

--- a/compose/app.yml
+++ b/compose/app.yml
@@ -15,7 +15,9 @@ services:
       - auth
       - redis
       - sidekiq
-      - mqtt-task
+      - mqtt-task-main-1
+      - mqtt-task-main-2
+      - mqtt-task-secondary
       - telnet-task
       #- mqtt
     restart: always

--- a/compose/db.yml
+++ b/compose/db.yml
@@ -1,6 +1,7 @@
 services:
    db:
     image: postgres:10
+    command: -c max_connections=200
     volumes:
       - sck-postgres:/var/lib/postgresql/data
     env_file: ../.env

--- a/compose/mqtt-task-common.yml
+++ b/compose/mqtt-task-common.yml
@@ -1,0 +1,14 @@
+services:
+  mqtt-task:
+    build: ../
+    env_file: ../.env
+    command: bundle exec rake mqtt:sub
+    restart: always
+    volumes:
+      - "../log:/app/log"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+    environment:
+      db_pool_size: 2

--- a/compose/mqtt-task-common.yml
+++ b/compose/mqtt-task-common.yml
@@ -11,4 +11,4 @@ services:
       options:
         max-size: "100m"
     environment:
-      db_pool_size: 2
+      db_pool_size: 5

--- a/compose/mqtt-task-common.yml
+++ b/compose/mqtt-task-common.yml
@@ -2,7 +2,7 @@ services:
   mqtt-task:
     build: ../
     env_file: ../.env
-    command: bundle exec rake mqtt:sub
+    command: ./mqtt_subscriber.sh
     restart: always
     volumes:
       - "../log:/app/log"

--- a/compose/mqtt-task.yml
+++ b/compose/mqtt-task.yml
@@ -18,7 +18,7 @@ services:
       file: mqtt-task-common.yml
       service: mqtt-task
     environment: 
-      MQTT_CLIENT_ID: "smartcitizen-api-staging-secondary-${HOSTNAME}"
+      MQTT_CLIENT_ID: "smartcitizen-api-staging-secondary"
       MQTT_CLEAN_SESSION: true
     deploy:
       mode: replicated

--- a/compose/mqtt-task.yml
+++ b/compose/mqtt-task.yml
@@ -1,14 +1,27 @@
 services:
-  mqtt-task:
-    build: ../
-    env_file: ../.env
-    command: bundle exec rake mqtt:sub
-    restart: always
-    volumes:
-      - "../log:/app/log"
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "100m"
-    environment:
-      db_pool_size: 5
+  mqtt-task-main-1:
+    extends:
+      file: mqtt-task-common.yml
+      service: mqtt-task
+    environment: 
+      MQTT_CLIENT_ID: smartcitizen-api-staging-main-1
+      MQTT_CLEAN_SESSION: false
+  mqtt-task-main-2:
+    extends:
+      file: mqtt-task-common.yml
+      service: mqtt-task
+    environment: 
+      MQTT_CLIENT_ID: smartcitizen-api-staging-main-2
+      MQTT_CLEAN_SESSION: false
+  mqtt-task-secondary:
+    extends:
+      file: mqtt-task-common.yml
+      service: mqtt-task
+    environment: 
+      MQTT_CLIENT_ID: "smartcitizen-api-staging-secondary-${HOSTNAME}"
+      MQTT_CLEAN_SESSION: true
+    deploy:
+      mode: replicated
+      replicas: 2
+
+

--- a/compose/telnet-task.yml
+++ b/compose/telnet-task.yml
@@ -5,4 +5,4 @@ services:
     command: bundle exec rake telnet:push
     restart: always
     environment:
-      db_pool_size: 5
+      db_pool_size: 2

--- a/db/migrate/20241009174732_unique_index_on_components.rb
+++ b/db/migrate/20241009174732_unique_index_on_components.rb
@@ -1,0 +1,23 @@
+class UniqueIndexOnComponents < ActiveRecord::Migration[6.1]
+  def up
+    remove_index :components, [:device_id, :sensor_id]
+    add_index :components, [:device_id, :sensor_id], unique: true
+    execute %{
+      ALTER TABLE components ADD CONSTRAINT unique_sensor_for_device UNIQUE (device_id, sensor_id)
+    }
+    execute %{
+      ALTER TABLE components ADD CONSTRAINT unique_key_for_device UNIQUE (device_id, key)
+    }
+  end
+
+  def down
+    execute %{
+      ALTER TABLE components DROP CONSTRAINT IF EXISTS unique_key_for_device
+    }
+    execute %{
+      ALTER TABLE components DROP CONSTRAINT IF EXISTS unique_sensor_for_device
+    }
+    remove_index :components, [:device_id, :sensor_id], unique: true
+    add_index :components, [:device_id, :sensor_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_10_01_080033) do
-
+ActiveRecord::Schema.define(version: 2024_10_09_174732) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "adminpack"
   enable_extension "hstore"
@@ -66,7 +65,9 @@ ActiveRecord::Schema.define(version: 2024_10_01_080033) do
     t.string "key"
     t.integer "bus", default: 1, null: false
     t.datetime "last_reading_at"
-    t.index ["device_id", "sensor_id"], name: "index_components_on_device_id_and_sensor_id"
+    t.index ["device_id", "key"], name: "unique_key_for_device", unique: true
+    t.index ["device_id", "sensor_id"], name: "index_components_on_device_id_and_sensor_id", unique: true
+    t.index ["device_id", "sensor_id"], name: "unique_sensor_for_device", unique: true
   end
 
   create_table "devices", id: :serial, force: :cascade do |t|

--- a/env.example
+++ b/env.example
@@ -18,6 +18,7 @@ REDIS_STORE=redis://redis:6379/3
 
 # MQTT Settings
 MQTT_HOST=mqtt
+#MQTT_SHARED_SUBSCRIPTION_GROUP="group1"
 #MQTT_CLEAN_SESSION=true
 #MQTT_CLIENT_ID=some_id
 #MQTT_PORT=port

--- a/lib/tasks/mqtt_subscriber.rake
+++ b/lib/tasks/mqtt_subscriber.rake
@@ -60,9 +60,11 @@ namespace :mqtt do
               end
               mqtt_log.info "Processed MQTT message in #{time}"
               mqtt_log.info "MQTT queue length: #{client.queue_length}"
-              if !threshold_passed && client.queue_length >= mqtt_queue_length_warning_threshold
-                threshold_passed = true
-                Sentry.capture_message("Warning: Internal MQTT queue length is #{client.queue_length} (>= #{mqtt_queue_length_warning_threshold} on client #{mqtt_client_id}).")
+              if client.queue_length >= mqtt_queue_length_warning_threshold
+                if !threshold_passed
+                  Sentry.capture_message("Warning: Internal MQTT queue length is #{client.queue_length} (>= #{mqtt_queue_length_warning_threshold} on client #{mqtt_client_id}).")
+                  threshold_passed = true
+                end
               else
                 threshold_passed = false
               end

--- a/lib/tasks/mqtt_subscriber.rake
+++ b/lib/tasks/mqtt_subscriber.rake
@@ -10,7 +10,7 @@ namespace :mqtt do
     mqtt_port = ENV.has_key?('MQTT_PORT') ? ENV['MQTT_PORT'] : 1883
     mqtt_ssl = ENV.has_key?('MQTT_SSL') ? ENV['MQTT_SSL'] : false
     mqtt_shared_subscription_group = ENV.fetch("MQTT_SHARED_SUBSCRIPTION_GROUP", nil)
-    mqtt_queue_length_warning_threshold = ENV.fetch("MQTT_QUEUE_LENGTH_WARNING_THRESHOLD", 30)
+    mqtt_queue_length_warning_threshold = ENV.fetch("MQTT_QUEUE_LENGTH_WARNING_THRESHOLD", "30").to_i
 
     mqtt_topics_string = ENV.fetch('MQTT_TOPICS', '')
     mqtt_topics = mqtt_topics_string.include?(",") ? mqtt_topics_string.split(",") : [ mqtt_topics_string ]

--- a/lib/tasks/mqtt_subscriber.rake
+++ b/lib/tasks/mqtt_subscriber.rake
@@ -10,8 +10,14 @@ namespace :mqtt do
     mqtt_port = ENV.has_key?('MQTT_PORT') ? ENV['MQTT_PORT'] : 1883
     mqtt_ssl = ENV.has_key?('MQTT_SSL') ? ENV['MQTT_SSL'] : false
     mqtt_shared_subscription_group = ENV.fetch("MQTT_SHARED_SUBSCRIPTION_GROUP", nil)
+    
     mqtt_topics_string = ENV.fetch('MQTT_TOPICS', '')
     mqtt_topics = mqtt_topics_string.include?(",") ? mqtt_topics_string.split(",") : [ mqtt_topics_string ]
+
+    if mqtt_shared_subscription_group && mqtt_clean_session
+      mqtt_client_id += "-#{ENV.fetch("HOSTNAME")}"
+    end
+ 
     mqtt_log = Logger.new("log/mqtt-#{mqtt_client_id}.log", 5, 100.megabytes)
     mqtt_log.info('MQTT TASK STARTING')
     mqtt_log.info("clean_session: #{mqtt_clean_session}")

--- a/lib/tasks/mqtt_subscriber.rake
+++ b/lib/tasks/mqtt_subscriber.rake
@@ -10,7 +10,7 @@ namespace :mqtt do
     mqtt_port = ENV.has_key?('MQTT_PORT') ? ENV['MQTT_PORT'] : 1883
     mqtt_ssl = ENV.has_key?('MQTT_SSL') ? ENV['MQTT_SSL'] : false
     mqtt_shared_subscription_group = ENV.fetch("MQTT_SHARED_SUBSCRIPTION_GROUP", nil)
-    mqtt_queue_length_warning_threshold = Env.fetch("MQTT_QUEUE_LENGTH_WARNING_THRESHOLD", 30)
+    mqtt_queue_length_warning_threshold = ENV.fetch("MQTT_QUEUE_LENGTH_WARNING_THRESHOLD", 30)
 
     mqtt_topics_string = ENV.fetch('MQTT_TOPICS', '')
     mqtt_topics = mqtt_topics_string.include?(",") ? mqtt_topics_string.split(",") : [ mqtt_topics_string ]

--- a/mqtt_subscriber.sh
+++ b/mqtt_subscriber.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+bundle exec rake mqtt:sub

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Component, :type => :model do
 
   it "validates uniqueness of board to sensor" do
     component = create(:component, device: create(:device), sensor: create(:sensor))
-    expect{ create(:component, device: component.device, sensor: component.sensor) }.to raise_error(ActiveRecord::RecordInvalid)
+    expect{ create(:component, device: component.device, sensor: component.sensor) }.to raise_error(ActiveRecord::RecordNotUnique)
   end
 
   describe "creating a unique sensor key" do

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -645,19 +645,19 @@ RSpec.describe Device, :type => :model do
     end
   end
 
-  describe "#find_or_create_component_by_sensor_id" do
+  describe "#create_or_find_component_by_sensor_id" do
     context "when the sensor exists and a component already exists for this device" do
       it "returns the existing component" do
         sensor = create(:sensor)
         component = create(:component, sensor: sensor, device: device)
-        expect(device.find_or_create_component_by_sensor_id(sensor.id)).to eq(component)
+        expect(device.create_or_find_component_by_sensor_id(sensor.id)).to eq(component)
       end
     end
 
     context "when the sensor exists and a component does not already exist for this device" do
       it "returns a new valid component with the correct sensor and device" do
         sensor = create(:sensor)
-        component = device.find_or_create_component_by_sensor_id(sensor.id)
+        component = device.create_or_find_component_by_sensor_id(sensor.id)
         expect(component).not_to be_blank
         expect(component).to be_a Component
         expect(component.valid?).to be(true)
@@ -670,13 +670,13 @@ RSpec.describe Device, :type => :model do
     context "when no sensor exists with this id" do
       it "returns nil" do
         create(:sensor, id: 12345)
-        expect(device.find_or_create_component_by_sensor_id(54321)).to be_blank
+        expect(device.create_or_find_component_by_sensor_id(54321)).to be_blank
       end
     end
 
     context "when the id is nil" do
       it "returns nil" do
-        expect(device.find_or_create_component_by_sensor_id(nil)).to be_blank
+        expect(device.create_or_find_component_by_sensor_id(nil)).to be_blank
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -74,7 +74,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -74,7 +74,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = false
+  config.use_transactional_fixtures = true
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,6 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-require "database_cleaner/active_record"
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
@@ -38,18 +37,6 @@ RSpec.configure do |config|
     # a real object. This is generally recommended, and will default to
     # `true` in RSpec 4.
     mocks.verify_partial_doubles = true
-  end
-
-  DatabaseCleaner.strategy = :truncation
-
-  config.before(:suite) do
-    DatabaseCleaner.clean
-  end
-
-  config.around(:each) do |example|
-    DatabaseCleaner.cleaning do
-      example.run
-    end
   end
 
 # The settings below are suggested to provide a good initial experience

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-
+require "database_cleaner/active_record"
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
@@ -38,6 +38,18 @@ RSpec.configure do |config|
     # a real object. This is generally recommended, and will default to
     # `true` in RSpec 4.
     mocks.verify_partial_doubles = true
+  end
+
+  DatabaseCleaner.strategy = :truncation
+
+  config.before(:suite) do
+    DatabaseCleaner.clean
+  end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
   end
 
 # The settings below are suggested to provide a good initial experience


### PR DESCRIPTION
Addresses #355, allowing us to scale the mqtt task through parallel processing. We have two named "main" subscribers which ensure that messages are not dropped in the event of downtime (they have consistent client ids and persistent sessions), and a secondary subscriber role (with transient ids and clean sessions) which can be scaled with load. Needs *thorough* testing on staging before deployment!

:warning: **on deployment, we need to:** :warning:

 - **bring down the app entirely, including the old mqtt-task**
 -  **delete the old "mqtt subscriber" client in emqx, so that no messages are retained for it, as the client id changes in this release**
 -  **run migrations BEFORE bringing up the mqtt-task again, as otherwise duplicate components will be created**
 - **bring up the entire stack again**