### PR TITLE
New Raw MQTT Message parser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ gem 'sentry-sidekiq'
 gem 'sinatra'
 #gem 'skylight'
 gem 'stamp'
+gem "treetop"
 gem 'versionist', github: 'bploetz/versionist'
 gem 'webrick'
 gem 'workflow'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,6 +307,7 @@ GEM
     pg_search (2.3.6)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
+    polyglot (0.3.5)
     premailer (1.21.0)
       addressable
       css_parser (>= 1.12.0)
@@ -502,6 +503,8 @@ GEM
     tilt (2.0.11)
     timecop (0.9.6)
     timeout (0.3.2)
+    treetop (1.6.12)
+      polyglot (~> 0.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unaccent (0.4.0)
@@ -604,6 +607,7 @@ DEPENDENCIES
   sshkit-sudo
   stamp
   timecop
+  treetop
   vcr
   versionist!
   webmock
@@ -616,4 +620,4 @@ RUBY VERSION
    ruby 3.0.6p216
 
 BUNDLED WITH
-   2.5.6
+   2.5.20

--- a/app/grammars/raw_message.tt
+++ b/app/grammars/raw_message.tt
@@ -1,0 +1,57 @@
+grammar RawMessage
+  rule message
+    '{' message_body '}' {
+      def to_hash
+        message_body.to_hash
+      end
+    }
+  end
+
+  rule message_body
+    (pairs:pair*) {
+      def to_hash
+        pairs.elements.inject({}) {|m, p| m.merge(p.to_hash) }
+      end
+    }
+  end
+
+  rule pair
+    key ':' value (','?) {
+      def to_hash
+        { key.to_sym => value.to_number }
+      end
+    }
+  end
+
+  rule key
+    key:(number / 't') {
+      def to_sym
+        key.text_value.to_sym
+      end
+    }
+  end
+
+  rule value
+    float / number
+  end
+
+  rule float
+    float:(number decimal_part) {
+      def to_number
+        float.text_value.to_f
+      end
+    }
+  end
+
+  rule number
+    number:[0-9]+ {
+      def to_number
+        number.text_value.to_i
+      end
+    }
+  end
+
+  rule decimal_part
+    '.' number
+  end
+end

--- a/app/grammars/raw_message.tt
+++ b/app/grammars/raw_message.tt
@@ -2,7 +2,7 @@ grammar RawMessage
   rule message
     '{' message_body '}' {
       def to_hash
-        message_body.to_hash
+        { data: [ message_body.to_hash ] }
       end
     }
   end
@@ -10,23 +10,39 @@ grammar RawMessage
   rule message_body
     (pairs:pair*) {
       def to_hash
-        pairs.elements.inject({}) {|m, p| m.merge(p.to_hash) }
+        pairs.elements.inject({ recorded_at: nil, sensors: [] }) { |accum, pair_node|
+          pair = pair_node.to_value
+          if pair[:key] == :t
+            accum.merge(recorded_at: pair[:value])
+          else
+            new_sensors_list = accum[:sensors] + [{id: pair[:key], value: pair[:value]}]
+            accum.merge(sensors: new_sensors_list)
+          end
+        }
       end
     }
   end
 
   rule pair
-    key ':' value (','?) {
-      def to_hash
-        { key.to_sym => value.to_number }
+    pair:(timestamp_pair / value_pair) ","? {
+      def to_value
+        pair.to_value
       end
     }
   end
 
-  rule key
-    key:(number / 't') {
-      def to_sym
-        key.text_value.to_sym
+  rule timestamp_pair
+    't:' timestamp {
+      def to_value
+        { key: :t, value: timestamp.text_value }
+      end
+    }
+  end
+
+  rule value_pair
+    number ':' value {
+      def to_value
+         { key: number.text_value, value: value.text_value }
       end
     }
   end
@@ -37,16 +53,16 @@ grammar RawMessage
 
   rule float
     float:(number decimal_part) {
-      def to_number
-        float.text_value.to_f
+      def to_value
+        float.text_value
       end
     }
   end
 
   rule number
-    number:[0-9]+ {
-      def to_number
-        number.text_value.to_i
+    number:[\-0-9]+ {
+      def to_value
+        number.text_value
       end
     }
   end
@@ -54,4 +70,13 @@ grammar RawMessage
   rule decimal_part
     '.' number
   end
+
+  rule timestamp
+    timestamp:([0-9] 4..4 '-' [0-9] 2..2 '-' [0-9] 2..2 'T' [0-9] 2..2 ':' [0-9] 2..2 ':' [0-9] 2..2 'Z') {
+      def to_value
+        Time.parse(timestamp.text_value)
+      end
+    }
+  end
+
 end

--- a/app/lib/raw_mqtt_message_parser.rb
+++ b/app/lib/raw_mqtt_message_parser.rb
@@ -6,7 +6,7 @@ class RawMQTTMessageParser
   end
 
   def parse(message)
-    parser.parse(self.convert_to_ascii(message)).to_hash
+    parser.parse(self.convert_to_ascii(message))&.to_hash
   end
 
   private

--- a/app/lib/raw_mqtt_message_parser.rb
+++ b/app/lib/raw_mqtt_message_parser.rb
@@ -1,0 +1,19 @@
+require_relative "../grammars/raw_message"
+
+class RawMQTTMessageParser
+  def initialize
+    @parser = RawMessageParser.new
+  end
+
+  def parse(message)
+    parser.parse(self.convert_to_ascii(message)).to_hash
+  end
+
+  private
+
+  def convert_to_ascii(string)
+    string.encode("US-ASCII", invalid: :replace, undef: :replace, replace: "")
+  end
+
+  attr_reader :parser
+end


### PR DESCRIPTION
Addressing #326 and errors in sentry arising from weird unicode characters in messages, also quite a nice refactoring, i think,

Uses a treetop parsing expression grammar for our "pseudojson" format, and use it to convert directly to the "non raw" extended json