### PR TITLE
slim world map representation and add gzip middleware

### DIFF
--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -203,18 +203,17 @@ class Device < ActiveRecord::Base
     end
   end
 
-  def formatted_location
+  def formatted_location(slim = false)
     {
-      ip: nil,
       exposure: exposure,
-      elevation: elevation.try(:to_i) ,
+      elevation: slim ? nil : elevation.try(:to_i),
       latitude: latitude,
       longitude: longitude,
-      geohash: geohash,
+      geohash: slim ? nil : geohash,
       city: city,
-      country_code: country_code,
+      country_code: slim ? nil : country_code,
       country: country_name
-    }
+    }.compact
   end
 
   def formatted_data

--- a/app/views/v0/devices/_device.jbuilder
+++ b/app/views/v0/devices/_device.jbuilder
@@ -1,9 +1,7 @@
 local_assigns[:with_owner] = true unless local_assigns.has_key?(:with_owner)
 local_assigns[:with_data] = true unless local_assigns.has_key?(:with_data)
-local_assigns[:with_postprocessing] = true unless local_assigns.has_key?(:with_postprocessing)
 local_assigns[:with_location] = true unless local_assigns.has_key?(:with_location)
 local_assigns[:slim_owner] = false unless local_assigns.has_key?(:slim_owner)
-local_assigns[:never_authorized] = false unless local_assigns.has_key?(:never_authorized)
 
 json.(
   device,
@@ -24,7 +22,7 @@ json.(
     low_battery: device.notify_low_battery
   })
 
-authorized = !local_assigns[:never_authorized] && (current_user && (current_user.is_admin? || (device.owner_id && current_user.id == device.owner_id)))
+authorized = (current_user && (current_user.is_admin? || (device.owner_id && current_user.id == device.owner_id)))
 
 if authorized
   json.merge! device_token: device.device_token
@@ -32,7 +30,7 @@ if authorized
 else
   json.merge! device_token: '[FILTERED]'
 end
-json.merge!(postprocessing: device.postprocessing) if local_assigns[:with_postprocessing]
+json.merge!(postprocessing: device.postprocessing)
 json.merge!(location: device.formatted_location) if local_assigns[:with_location]
 json.merge!(data_policy: device.data_policy(authorized))
 json.merge!(hardware: device.hardware(authorized))

--- a/app/views/v0/devices/_world_map_device.jbuilder
+++ b/app/views/v0/devices/_world_map_device.jbuilder
@@ -1,0 +1,28 @@
+local_assigns[:never_authorized] = false unless local_assigns.has_key?(:never_authorized)
+
+json.(
+  device,
+  :id,
+  :name,
+  :description,
+  :state,
+  :system_tags,
+  :user_tags,
+  :last_reading_at,
+)
+
+
+authorized = !local_assigns[:never_authorized] && (current_user && (current_user.is_admin? || (device.owner_id && current_user.id == device.owner_id)))
+
+json.merge!(location: device.formatted_location(true))
+json.merge!(hardware: device.hardware(authorized))
+
+if device.owner
+  json.owner do
+    json.id device.owner.id
+    json.username device.owner.username
+    json.url device.owner.url
+  end
+end
+
+

--- a/app/views/v0/devices/_world_map_device.jbuilder
+++ b/app/views/v0/devices/_world_map_device.jbuilder
@@ -1,5 +1,3 @@
-local_assigns[:never_authorized] = false unless local_assigns.has_key?(:never_authorized)
-
 json.(
   device,
   :id,
@@ -11,18 +9,6 @@ json.(
   :last_reading_at,
 )
 
-
-authorized = !local_assigns[:never_authorized] && (current_user && (current_user.is_admin? || (device.owner_id && current_user.id == device.owner_id)))
-
 json.merge!(location: device.formatted_location(true))
-json.merge!(hardware: device.hardware(authorized))
-
-if device.owner
-  json.owner do
-    json.id device.owner.id
-    json.username device.owner.username
-    json.url device.owner.url
-  end
-end
-
+json.merge!(hardware: device.hardware(false))
 

--- a/app/views/v0/devices/_world_map_list.jbuilder
+++ b/app/views/v0/devices/_world_map_list.jbuilder
@@ -1,1 +1,1 @@
-json.array! Device.for_world_map(never_authorized ? nil : current_user), partial: 'device', as: :device, local_assigns: { with_data: false, with_postprocessing: false, slim_owner: true, never_authorized: never_authorized }
+json.array! Device.for_world_map(never_authorized ? nil : current_user), partial: 'world_map_device', as: :device, local_assigns: { never_authorized: never_authorized }

--- a/app/views/v0/devices/_world_map_list.jbuilder
+++ b/app/views/v0/devices/_world_map_list.jbuilder
@@ -1,1 +1,1 @@
-json.array! Device.for_world_map(never_authorized ? nil : current_user), partial: 'world_map_device', as: :device, local_assigns: { never_authorized: never_authorized }
+json.array! Device.for_world_map(never_authorized ? nil : current_user), partial: 'world_map_device', as: :device

--- a/config/application.rb
+++ b/config/application.rb
@@ -73,5 +73,6 @@ module Smartcitizen
 
     config.api_only = true
     config.active_storage.service_urls_expire_in = 30.minutes
+    config.middleware.use Rack::Deflater
   end
 end


### PR DESCRIPTION
Only send the fields we need to render the world map. We also add Rack::Deflate middleware to gzip all json responses.

Partially addresses: https://github.com/fablabbcn/smartcitizen-web/issues/451#issuecomment-2402331215

Overall, this cuts the weight of the world map from ~4.5MB to ~250k, and the response time down to approx 1.5 sec.

The speed up from caching the /world_map endpoint is now negligible, so we might think about removing that once we've verified that this all works correctly.