### PR TITLE
Add healthcheck on web to restart based on curl

### DIFF
--- a/compose/web.yml
+++ b/compose/web.yml
@@ -5,6 +5,11 @@ services:
       app:
         condition: service_healthy
         restart: true
+    healthcheck:
+      test: ["CMD-SHELL", "curl http://app:3000"]
+      timeout: 10s
+      start-period: 5s
+    restart: always
     ports:
       - 80:80
       - 80:80/udp


### PR DESCRIPTION
This is another attempt to help with `web` not restarting when `app` falls over. It adds a `healthcheck` on **runtime** to the web container. It seems that the `depends_on` done in https://github.com/fablabbcn/smartcitizen-api/pull/360 only works for docker compose operations, not in runtime. 

This is indicated in the documentation: https://docs.docker.com/reference/compose-file/services/#depends_on

> restart: When set to true Compose restarts this service after it updates the dependency service. This applies to an explicit restart controlled by a Compose operation, and excludes automated restart by the container runtime after the container dies. Introduced in Docker Compose version 2.17.0.

