### PR TITLE
Postprocessing data read enhancements

### DIFF
--- a/app/models/kairos.rb
+++ b/app/models/kairos.rb
@@ -15,6 +15,8 @@ class Kairos
     rollup_value = params[:rollup].to_i
     rollup_unit = Kairos.get_timespan( params[:rollup].gsub(rollup_value.to_s,'') )
 
+    limit = params[:limit]&.to_i
+
     device = Device.find(params[:id])
 
     if sensor_key = params[:sensor_key]
@@ -25,6 +27,7 @@ class Kairos
     end
 
     component = device.find_component_by_sensor_id(sensor_id)
+
 
     unless component
       return {
@@ -44,6 +47,7 @@ class Kairos
     metrics = [{
       tags: { device_id: params[:id] },
       name: sensor_key,
+      limit: limit,
       aggregators: [
         {
           name: function,
@@ -54,7 +58,7 @@ class Kairos
           }
         }
       ]
-    }]
+    }.compact]
 
     data = { metrics: metrics, cache_time: 0 }
 

--- a/spec/requests/v0/password_resets_spec.rb
+++ b/spec/requests/v0/password_resets_spec.rb
@@ -117,7 +117,6 @@ describe V0::PasswordResetsController do
     it "can reset password with valid token" do
       expect(user.authenticate('newpass')).to be_falsey
       j = api_put "password_resets/#{user.password_reset_token}", { password: 'newpass' }
-      p response
       expect(j["username"]).to eq(user.username)
       expect(response.status).to eq(200)
 


### PR DESCRIPTION
Fixes #374, gives each device a `first_reading_at` property, populated on ingest, and allows passing of a `limit` parameter to the readings endpoint (applied **before** rollups)

:rotating_light: REQUIRES migrations and the `devices:set_first_reading_at` task to be run on deploy :rotating_light: 