### PR TITLE
don't log 404s in sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,5 @@
 Sentry.init do |config|
   config.dsn = ENV['RAVEN_DSN_URL']
   config.breadcrumbs_logger = [:sentry_logger, :active_support_logger, :http_logger]
-  config.excluded_exceptions = ["RetryMQTTMessageJob::RetryMessageHandlerError"]
+  config.excluded_exceptions = ["RetryMQTTMessageJob::RetryMessageHandlerError", 'ActionController::RoutingError', 'ActiveRecord::RecordNotFound']
 end


### PR DESCRIPTION
We don't want to use up our Sentry quota with errors which are simple 404s