### PR TITLE
SPIKE -  generalised device identifiers (NOT FOR MERGING)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@
 
 #require: rubocop-rails
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
   Exclude:
     - 'db/schema.rb'

--- a/.solargraph.yml
+++ b/.solargraph.yml
@@ -1,0 +1,2 @@
+plugins:
+  - solargraph-rails

--- a/app/models/device_identifier.rb
+++ b/app/models/device_identifier.rb
@@ -1,0 +1,21 @@
+class DeviceIdentifier < ActiveRecord::Base
+  belongs_to :device
+
+  validates_presence_of :device, :namespace, :identifier
+  validates_inclusion_of :is_archived, in: [false, true]
+  validates_uniqueness_of :identifier, scope: %i[device namespace is_archived]
+
+  def self.archive_all(namespace, identifier)
+    where(namespace: namespace, identifier: identifier).each(&:archive!)
+  end
+
+  def archive!
+    self.is_archived = true
+    save!
+  end
+
+  def unarchive!
+    self.is_archived = false
+    save!
+  end
+end

--- a/app/models/raw_storer.rb
+++ b/app/models/raw_storer.rb
@@ -13,7 +13,7 @@ class RawStorer
       readings = {}
 
       mac = mac.downcase.strip
-      device = Device.includes(:components).where(mac_address: mac).last
+      device = Device.find_by_identifier(:mac_address, mac)
 
       identifier = version.split('-').first
 

--- a/db/migrate/20250703094510_create_device_identifiers.rb
+++ b/db/migrate/20250703094510_create_device_identifiers.rb
@@ -1,0 +1,33 @@
+class CreateDeviceIdentifiers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :device_identifiers do |t|
+      t.references :device, null: false, foreign_key: true
+      t.string :namespace, null: false
+      t.string :identifier, null: false
+      t.boolean :is_archived, null: false, default: false
+      t.timestamps
+    end
+
+    add_index :device_identifiers, %i[is_archived namespace identifier], name: "index_devices_by_archived_ns_id"
+
+    execute %(
+      INSERT INTO device_identifiers
+        (device_id, namespace, identifier, is_archived, created_at, updated_at)
+        SELECT id, 'mac_address', mac_address, FALSE, NOW(), NOW()
+        FROM devices
+        WHERE mac_address IS NOT NULL
+    )
+
+    execute %(
+      INSERT INTO device_identifiers
+        (device_id, namespace, identifier, is_archived, created_at, updated_at)
+        SELECT id, 'mac_address', old_mac_address, TRUE, NOW(), NOW()
+        FROM devices
+        WHERE old_mac_address IS NOT NULL
+    )
+
+    remove_column :devices, :mac_address
+    remove_column :devices, :old_mac_address
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_05_05_081245) do
+ActiveRecord::Schema.define(version: 2025_07_03_094510) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "adminpack"
@@ -71,11 +71,21 @@ ActiveRecord::Schema.define(version: 2025_05_05_081245) do
     t.index ["device_id", "sensor_id"], name: "unique_sensor_for_device", unique: true
   end
 
+  create_table "device_identifiers", force: :cascade do |t|
+    t.bigint "device_id", null: false
+    t.string "namespace", null: false
+    t.string "identifier", null: false
+    t.boolean "is_archived", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["device_id"], name: "index_device_identifiers_on_device_id"
+    t.index ["is_archived", "namespace", "identifier"], name: "index_devices_by_archived_ns_id"
+  end
+
   create_table "devices", id: :serial, force: :cascade do |t|
     t.integer "owner_id"
     t.string "name"
     t.text "description"
-    t.macaddr "mac_address"
     t.float "latitude"
     t.float "longitude"
     t.datetime "created_at", null: false
@@ -92,7 +102,6 @@ ActiveRecord::Schema.define(version: 2025_05_05_081245) do
     t.jsonb "migration_data"
     t.string "workflow_state"
     t.datetime "csv_export_requested_at"
-    t.macaddr "old_mac_address"
     t.string "state"
     t.string "device_token"
     t.jsonb "hardware_info"
@@ -346,6 +355,7 @@ ActiveRecord::Schema.define(version: 2025_05_05_081245) do
   add_foreign_key "api_tokens", "users", column: "owner_id"
   add_foreign_key "components", "devices"
   add_foreign_key "components", "sensors"
+  add_foreign_key "device_identifiers", "devices"
   add_foreign_key "devices_experiments", "devices"
   add_foreign_key "devices_experiments", "experiments"
   add_foreign_key "devices_tags", "devices"


### PR DESCRIPTION
I think we should defer this to think properly about after the meshtastic hackday, but wanted to keep this partial implementation around for discussion:

I'm thinking about a way of generalising "device identifiers" into their own model, so we have a simple, consistent method for identifying devices by mac address, device key, meshtastic id, or any other identification scheme that might come along in future. 

For the hackday, i think this is overkill, as it's a bit more subtle to implement than i thought, and a new "meshtastic_id" column is probably a safer option, but it might be nice to revisit this as a later refactoring.

